### PR TITLE
Change arguments and return of convert_idf_to_trnbuild()

### DIFF
--- a/archetypal/__init__.py
+++ b/archetypal/__init__.py
@@ -7,7 +7,6 @@
 
 __version__ = '1.2.0-dev'
 
-from .settings import *
 from .utils import *
 from .simple_glazing import *
 from .idfclass import IDF

--- a/archetypal/settings.py
+++ b/archetypal/settings.py
@@ -116,3 +116,6 @@ default_crs = {'init': 'epsg:4326'}
 
 # unique schedule number as list
 unique_schedules = []
+
+# TRNSYS default location
+trnsys_default_folder = r"C:\TRNSYS18"

--- a/archetypal/trnsys.py
+++ b/archetypal/trnsys.py
@@ -8,6 +8,7 @@
 import logging as lg
 import os
 import subprocess
+import sys
 import time
 import re
 from collections import OrderedDict
@@ -17,8 +18,8 @@ import pandas as pd
 from eppy import modeleditor
 from geomeppy.geom.polygons import Polygon3D
 
-from archetypal import log, settings, Schedule
-import archetypal as ar
+from archetypal import log, settings, Schedule, load_idf, checkStr, \
+    check_unique_name
 
 
 def clear_name_idf_objects(idfFile):
@@ -76,9 +77,9 @@ def clear_name_idf_objects(idfFile):
                     new_name = first_letters + '_' + end_count
 
                     # Make sure new name does not already exist
-                    new_name = ar.check_unique_name(first_letters, count,
-                                                     new_name,
-                                         uniqueList)
+                    new_name = check_unique_name(first_letters, count,
+                                                 new_name,
+                                                 uniqueList)
 
                     uniqueList.append(new_name)
 
@@ -496,8 +497,8 @@ def convert_idf_to_trnbuild(idf_file, window_lib, return_b18=True,
     # Write VERSION from IDF to lines (T3D)
     # Get line number where to write
     with open(ori_idf_filepath) as ori:
-        versionNum = ar.checkStr(ori,
-                                 'ALL OBJECTS IN CLASS: VERSION')
+        versionNum = checkStr(ori,
+                              'ALL OBJECTS IN CLASS: VERSION')
     # Writing VERSION infos to lines
     for i in range(0, len(versions)):
         lines.insert(versionNum,
@@ -505,16 +506,16 @@ def convert_idf_to_trnbuild(idf_file, window_lib, return_b18=True,
 
     # Write BUILDING from IDF to lines (T3D)
     # Get line number where to write
-    buildingNum = ar.checkStr(lines,
-                              'ALL OBJECTS IN CLASS: BUILDING')
+    buildingNum = checkStr(lines,
+                           'ALL OBJECTS IN CLASS: BUILDING')
     # Writing BUILDING infos to lines
     for building in buildings:
         lines.insert(buildingNum, building)
 
     # Write LOCATION and GLOBALGEOMETRYRULES from IDF to lines (T3D)
     # Get line number where to write
-    locationNum = ar.checkStr(lines,
-                              'ALL OBJECTS IN CLASS: LOCATION')
+    locationNum = checkStr(lines,
+                           'ALL OBJECTS IN CLASS: LOCATION')
 
     # Writing GLOBALGEOMETRYRULES infos to lines
     for globGeomRule in globGeomRules:
@@ -557,9 +558,9 @@ def convert_idf_to_trnbuild(idf_file, window_lib, return_b18=True,
     # region Write VARIABLEDICTONARY (Zone, BuildingSurf, FenestrationSurf)
     # from IDF to lines (T3D)
     # Get line number where to write
-    variableDictNum = ar.checkStr(lines,
-                                  'ALL OBJECTS IN CLASS: '
-                                  'OUTPUT:VARIABLEDICTIONARY')
+    variableDictNum = checkStr(lines,
+                               'ALL OBJECTS IN CLASS: '
+                               'OUTPUT:VARIABLEDICTIONARY')
 
     # Writing zones in lines
     count_fs = 0
@@ -730,7 +731,7 @@ def convert_idf_to_trnbuild(idf_file, window_lib, return_b18=True,
 
     # region Write CONSTRUCTION from IDF to lines (T3D)
     # Get line number where to write
-    constructionNum = ar.checkStr(lines, 'C O N S T R U C T I O N')
+    constructionNum = checkStr(lines, 'C O N S T R U C T I O N')
 
     # Writing CONSTRUCTION in lines
     for i in range(0, len(constructions.list2)):
@@ -786,8 +787,8 @@ def convert_idf_to_trnbuild(idf_file, window_lib, return_b18=True,
 
     # Write CONSTRUCTION from IDF to lines, at the end of the T3D file
     # Get line number where to write
-    constructionEndNum = ar.checkStr(lines,
-                                     'ALL OBJECTS IN CLASS: CONSTRUCTION')
+    constructionEndNum = checkStr(lines,
+                                  'ALL OBJECTS IN CLASS: CONSTRUCTION')
 
     # Writing CONSTRUCTION infos to lines
     for i in range(0, len(constructions)):
@@ -802,7 +803,7 @@ def convert_idf_to_trnbuild(idf_file, window_lib, return_b18=True,
 
     # region Write LAYER from IDF to lines (T3D)
     # Get line number where to write
-    layerNum = ar.checkStr(lines, 'L a y e r s')
+    layerNum = checkStr(lines, 'L a y e r s')
 
     # Writing MATERIAL infos to lines
     listLayerName = []
@@ -850,7 +851,7 @@ def convert_idf_to_trnbuild(idf_file, window_lib, return_b18=True,
 
     # region Write GAINS (People, Lights, Equipment) from IDF to lines (T3D)
     # Get line number where to write
-    gainNum = ar.checkStr(lines, 'G a i n s')
+    gainNum = checkStr(lines, 'G a i n s')
 
     # Writing PEOPLE gains infos to lines
     schedule_list_people = []
@@ -1000,8 +1001,8 @@ def convert_idf_to_trnbuild(idf_file, window_lib, return_b18=True,
         lg.INFO)
 
     # Get line number where to write
-    windowNum = ar.checkStr(lines,
-                            'W i n d o w s')
+    windowNum = checkStr(lines,
+                         'W i n d o w s')
     # Write
     lines.insert(windowNum + 2,
                  '!- WINID = ' + str(window[0]) + ': HINSIDE = 11:'
@@ -1028,16 +1029,16 @@ def convert_idf_to_trnbuild(idf_file, window_lib, return_b18=True,
                                                   'undefined')
 
     # Get line number to write the EXTENSION_WINPOOL
-    extWinpoolNum = ar.checkStr(lines,
-                                '!-_EXTENSION_WINPOOL_START_')
+    extWinpoolNum = checkStr(lines,
+                             '!-_EXTENSION_WINPOOL_START_')
     count = 0
     for line in window[10]:
         lines.insert(extWinpoolNum + count, '!-' + line)
         count += 1
 
     # Get line number to write the Window description
-    winDescriptionNum = ar.checkStr(lines,
-                                    'WinID Description')
+    winDescriptionNum = checkStr(lines,
+                                 'WinID Description')
     lines.insert(winDescriptionNum + 1,
                  '!-' + str(window[0]) + ' ' + str(window[1])
                  + ' ' + str(window[2]) + ' ' + str(window[3]) + ' ' +

--- a/archetypal/utils.py
+++ b/archetypal/utils.py
@@ -28,8 +28,7 @@ import numpy as np
 import pandas as pd
 from pandas.io.json import json_normalize
 
-import archetypal as ar
-from archetypal import settings
+from . import settings
 
 
 def config(data_folder=settings.data_folder,
@@ -668,7 +667,7 @@ def copy_file(files, where=None):
 
     # defaults to cache folder
     if where is None:
-        where = ar.settings.cache_folder
+        where = settings.cache_folder
 
     for file in files:
         dst = os.path.join(where, file)

--- a/archetypal/utils.py
+++ b/archetypal/utils.py
@@ -44,7 +44,8 @@ def config(data_folder=settings.data_folder,
            log_filename=settings.log_filename,
            useful_idf_objects=settings.useful_idf_objects,
            umitemplate=settings.umitemplate,
-           get_common_umi_objects=False):
+           get_common_umi_objects=False,
+           trnsys_default_folder=settings.trnsys_default_folder):
     """
     Configurations
 
@@ -64,6 +65,7 @@ def config(data_folder=settings.data_folder,
         log_filename (str): name of the log file
         useful_idf_objects (list): a list of useful idf objects
         umitemplate (str): where the umitemplate is located
+        trnsys_default_folder (str): root folder of TRNSYS install
 
     Returns:
         None
@@ -82,6 +84,8 @@ def config(data_folder=settings.data_folder,
     settings.log_filename = log_filename
     settings.useful_idf_objects = useful_idf_objects
     settings.umitemplate = umitemplate
+    settings.trnsys_default_folder = validate_trnsys_folder(
+        trnsys_default_folder)
     if get_common_umi_objects:
         settings.common_umi_objects = get_list_of_common_umi_objects(
             settings.umitemplate)
@@ -89,6 +93,19 @@ def config(data_folder=settings.data_folder,
     # if logging is turned on, log that we are configured
     if settings.log_file or settings.log_console:
         log('Configured archetypal')
+
+
+def validate_trnsys_folder(trnsys_default_folder):
+    if sys.platform == 'win32':
+        if os.path.isdir(trnsys_default_folder):
+            return trnsys_default_folder
+        else:
+            raise ValueError('The provided TRNSYS path does not exist. Path={'
+                             '}'.format(trnsys_default_folder))
+    else:
+        return trnsys_default_folder
+
+
 
 
 def log(message, level=None, name=None, filename=None, avoid_console=False):

--- a/tests/test_dataportals.py
+++ b/tests/test_dataportals.py
@@ -1,6 +1,6 @@
 import archetypal as ar
 import pandas as pd
-# configure archetypal
+
 from archetypal import download_bld_window
 
 

--- a/tests/test_trnsys.py
+++ b/tests/test_trnsys.py
@@ -4,7 +4,8 @@ import sys
 
 import pytest
 
-from archetypal import convert_idf_to_t3d, parallel_process, parse_window_lib, \
+from archetypal import convert_idf_to_trnbuild, parallel_process, \
+    parse_window_lib, \
     choose_window, trnbuild_idf
 
 
@@ -20,26 +21,44 @@ def test_trnbuild_from_idf(config):
     window_file = 'W74-lib.dat'
     window_filepath = os.path.join("tests", "input_data", "trnsys", window_file)
 
-    convert_idf_to_t3d("tests/input_data/trnsys/NECB 2011 - Small Office.idf",
-                       window_filepath)
+    convert_idf_to_trnbuild(
+        "tests/input_data/trnsys/NECB 2011 - Small Office.idf", window_filepath)
 
 
 def test_trnbuild_from_idf_parallel(config):
+    # All IDF files
+    idf_list = ["NECB 2011 - Full Service Restaurant.idf", "NECB 2011 - "
+                                                           "HighRise "
+                                                           "Apartment.idf",
+                "NECB 2011 - Hospital.idf", "NECB 2011 - Large Hotel.idf",
+                "NECB 2011 - Medium Office.idf", "NECB 2011 - MidRise "
+                                                 "Apartment.idf", "NECB 2011 "
+                                                                  "- "
+                                                                  "Outpatient.idf",
+                "NECB 2011 - Primary School.idf",
+                "NECB 2011 - Quick Service Restaurant.idf", "NECB 2011 - "
+                                                            "Retail "
+                                                            "Standalone.idf",
+                "NECB 2011 - Retail Stripmall.idf", "NECB 2011 - "
+                                                    "Secondary School.idf",
+                "NECB 2011 - Small Hotel.idf", "NECB 2011 - Small "
+                                               "Office.idf", "NECB 2011 - "
+                                                             "Warehouse.idf"]
     # List files here
-    file_upper_path = 'tests/input_data/trnsys/'
+    file_upper_path = os.path.join('tests', 'input_data', 'trnsys')
     files = ["NECB 2011 - Warehouse.idf"]
 
     window_file = 'W74-lib.dat'
-    window_filepath = os.path.join("tests", "input_data", "trnsys", window_file)
+    window_filepath = os.path.join(file_upper_path, window_file)
 
     # prepare args (key=value). Key is a unique id for the runs (here the
     # file basename is used). Value is a dict of the function arguments
-    in_dict = {os.path.basename(file): {'idf_file': file_upper_path + file,
-                                        'window_lib': window_filepath,
-                                        'output_folder': None} for
+    in_dict = {os.path.basename(file): {'idf_file':
+                                            os.path.join(file_upper_path, file),
+                                        'window_lib': window_filepath} for
                file in files}
 
-    parallel_process(in_dict, convert_idf_to_t3d, 8, use_kwargs=True)
+    parallel_process(in_dict, convert_idf_to_trnbuild, 4, use_kwargs=True)
 
 
 def test_trnbuild_parse_window_lib(config):


### PR DESCRIPTION
-Add optional boolean arguments in convert_idf_to_trnbuild() to return the paths of the b18 or t3d or dck files.
-New: convert_idf_to_trnbuild() returns a tuple with the paths to the translated files (b18 or t3d or dck).
-Create (in settings) and validate (in utils), a global variable being the default path folder to TRNSYS.
-Add kwargs (optional) in convert_idf_to_trnbuild() (as dict) for keyword arguments sent to trnbuild_idf().
-Making sure that win32 is used to run trnbuild_idf().
-Change way to import functions from archetypal