### PR TITLE
Support IDF versions older than 7.2 on Travis-CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ before_install:
   - ENERGYPLUS_DOWNLOAD_BASE_URL=https://github.com/NREL/EnergyPlus/releases/download/v$ENERGYPLUS_VERSION
   - ENERGYPLUS_DOWNLOAD_FILENAME=EnergyPlus-$ENERGYPLUS_VERSION-$ENERGYPLUS_SHA-$PLATFORM-x86_64
   - ENERGYPLUS_DOWNLOAD_URL=$ENERGYPLUS_DOWNLOAD_BASE_URL/$ENERGYPLUS_DOWNLOAD_FILENAME.$EXT
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then EXTRAS_DOWNLOAD_URL=http://energyplus.helpserve
+    .com/Knowledgebase/Article/GetAttachment/97/8230; then curl -SLO $EXTRAS_DOWNLOAD_URL
   - curl -SLO $ENERGYPLUS_DOWNLOAD_URL
   
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
@@ -23,12 +25,14 @@ before_install:
     sudo installer -pkg /Volumes/$ENERGYPLUS_DOWNLOAD_FILENAME/$ENERGYPLUS_DOWNLOAD_FILENAME.pkg -target /; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     sudo chmod +x $ENERGYPLUS_DOWNLOAD_FILENAME.$EXT;
-    echo "y\r" | sudo ./$ENERGYPLUS_DOWNLOAD_FILENAME.$EXT; fi
+    echo "y\r" | sudo ./$ENERGYPLUS_DOWNLOAD_FILENAME.$EXT; then
+    sudo tar -C /usr/local/EnergyPlus-$ENERGYPLUS_INSTALL_VERSION/PreProcess/IDFVersionUpdater -xvf 8230; fi
   - if [ "$TRAVIS_OS_NAME" == "windows" ]; then
     sudo chmod +x $ENERGYPLUS_DOWNLOAD_FILENAME.$EXT;
     echo "y\r" | sudo ./$ENERGYPLUS_DOWNLOAD_FILENAME.$EXT; fi
   
   - sudo rm $ENERGYPLUS_DOWNLOAD_FILENAME.$EXT
+  - sudo rm 8230
   
   # Install python
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - ENERGYPLUS_DOWNLOAD_FILENAME=EnergyPlus-$ENERGYPLUS_VERSION-$ENERGYPLUS_SHA-$PLATFORM-x86_64
   - ENERGYPLUS_DOWNLOAD_URL=$ENERGYPLUS_DOWNLOAD_BASE_URL/$ENERGYPLUS_DOWNLOAD_FILENAME.$EXT
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ATTCH=97/8230; fi
-  - EXTRAS_DOWNLOAD_URL=http://energyplus.helpserve.com/Knowledgebase/Article/GetAttachment/$ATTCH; fi
+  - EXTRAS_DOWNLOAD_URL=http://energyplus.helpserve.com/Knowledgebase/Article/GetAttachment/$ATTCH
   - curl -SLO $ENERGYPLUS_DOWNLOAD_URL
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     curl -SLO $EXTRAS_DOWNLOAD_URL; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
     sudo installer -pkg /Volumes/$ENERGYPLUS_DOWNLOAD_FILENAME/$ENERGYPLUS_DOWNLOAD_FILENAME.pkg -target /; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     sudo chmod +x $ENERGYPLUS_DOWNLOAD_FILENAME.$EXT;
-    echo "y\r" | sudo ./$ENERGYPLUS_DOWNLOAD_FILENAME.$EXT; then
+    echo "y\r" | sudo ./$ENERGYPLUS_DOWNLOAD_FILENAME.$EXT;
     sudo tar -C /usr/local/EnergyPlus-$ENERGYPLUS_INSTALL_VERSION/PreProcess/IDFVersionUpdater -xvf 8230; fi
   - if [ "$TRAVIS_OS_NAME" == "windows" ]; then
     sudo chmod +x $ENERGYPLUS_DOWNLOAD_FILENAME.$EXT;

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ before_install:
   - ENERGYPLUS_DOWNLOAD_BASE_URL=https://github.com/NREL/EnergyPlus/releases/download/v$ENERGYPLUS_VERSION
   - ENERGYPLUS_DOWNLOAD_FILENAME=EnergyPlus-$ENERGYPLUS_VERSION-$ENERGYPLUS_SHA-$PLATFORM-x86_64
   - ENERGYPLUS_DOWNLOAD_URL=$ENERGYPLUS_DOWNLOAD_BASE_URL/$ENERGYPLUS_DOWNLOAD_FILENAME.$EXT
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then EXTRAS_DOWNLOAD_URL=http://energyplus.helpserve
-  - .com/Knowledgebase/Article/GetAttachment/97/8230;
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then EXTRAS_DOWNLOAD_URL=http://energyplus.helpserve.com/Knowledgebase/Article/GetAttachment/97/8230; fi
   - curl -SLO $ENERGYPLUS_DOWNLOAD_URL
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     curl -SLO $EXTRAS_DOWNLOAD_URL; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ before_install:
   - ENERGYPLUS_DOWNLOAD_BASE_URL=https://github.com/NREL/EnergyPlus/releases/download/v$ENERGYPLUS_VERSION
   - ENERGYPLUS_DOWNLOAD_FILENAME=EnergyPlus-$ENERGYPLUS_VERSION-$ENERGYPLUS_SHA-$PLATFORM-x86_64
   - ENERGYPLUS_DOWNLOAD_URL=$ENERGYPLUS_DOWNLOAD_BASE_URL/$ENERGYPLUS_DOWNLOAD_FILENAME.$EXT
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then EXTRAS_DOWNLOAD_URL=http://energyplus.helpserve.com/Knowledgebase/Article/GetAttachment/97/8230; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    EXTRAS_DOWNLOAD_URL=http://energyplus.helpserve.com/Knowledgebase/Article/GetAttachment/97/8230; fi
   - curl -SLO $ENERGYPLUS_DOWNLOAD_URL
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     curl -SLO $EXTRAS_DOWNLOAD_URL; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ before_install:
   - ENERGYPLUS_DOWNLOAD_BASE_URL=https://github.com/NREL/EnergyPlus/releases/download/v$ENERGYPLUS_VERSION
   - ENERGYPLUS_DOWNLOAD_FILENAME=EnergyPlus-$ENERGYPLUS_VERSION-$ENERGYPLUS_SHA-$PLATFORM-x86_64
   - ENERGYPLUS_DOWNLOAD_URL=$ENERGYPLUS_DOWNLOAD_BASE_URL/$ENERGYPLUS_DOWNLOAD_FILENAME.$EXT
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    EXTRAS_DOWNLOAD_URL=http://energyplus.helpserve.com/Knowledgebase/Article/GetAttachment/97/8230; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ATTCH=97/8230; fi
+  - EXTRAS_DOWNLOAD_URL=http://energyplus.helpserve.com/Knowledgebase/Article/GetAttachment/$ATTCH; fi
   - curl -SLO $ENERGYPLUS_DOWNLOAD_URL
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     curl -SLO $EXTRAS_DOWNLOAD_URL; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,11 @@ before_install:
   - ENERGYPLUS_DOWNLOAD_BASE_URL=https://github.com/NREL/EnergyPlus/releases/download/v$ENERGYPLUS_VERSION
   - ENERGYPLUS_DOWNLOAD_FILENAME=EnergyPlus-$ENERGYPLUS_VERSION-$ENERGYPLUS_SHA-$PLATFORM-x86_64
   - ENERGYPLUS_DOWNLOAD_URL=$ENERGYPLUS_DOWNLOAD_BASE_URL/$ENERGYPLUS_DOWNLOAD_FILENAME.$EXT
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then EXTRAS_DOWNLOAD_URL=http://energyplus.helpserve.com/Knowledgebase/Article/GetAttachment/97/8230; then curl -SLO $EXTRAS_DOWNLOAD_URL; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then EXTRAS_DOWNLOAD_URL=http://energyplus.helpserve
+  - .com/Knowledgebase/Article/GetAttachment/97/8230;
   - curl -SLO $ENERGYPLUS_DOWNLOAD_URL
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    curl -SLO $EXTRAS_DOWNLOAD_URL; fi
   
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     sudo hdiutil attach $ENERGYPLUS_DOWNLOAD_FILENAME.$EXT;

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ before_install:
   - ENERGYPLUS_DOWNLOAD_BASE_URL=https://github.com/NREL/EnergyPlus/releases/download/v$ENERGYPLUS_VERSION
   - ENERGYPLUS_DOWNLOAD_FILENAME=EnergyPlus-$ENERGYPLUS_VERSION-$ENERGYPLUS_SHA-$PLATFORM-x86_64
   - ENERGYPLUS_DOWNLOAD_URL=$ENERGYPLUS_DOWNLOAD_BASE_URL/$ENERGYPLUS_DOWNLOAD_FILENAME.$EXT
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then EXTRAS_DOWNLOAD_URL=http://energyplus.helpserve
-    .com/Knowledgebase/Article/GetAttachment/97/8230; then curl -SLO $EXTRAS_DOWNLOAD_URL
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then EXTRAS_DOWNLOAD_URL=http://energyplus.helpserve.com/Knowledgebase/Article/GetAttachment/97/8230; then curl -SLO $EXTRAS_DOWNLOAD_URL; fi
   - curl -SLO $ENERGYPLUS_DOWNLOAD_URL
   
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then


### PR DESCRIPTION
I added a command in the travais-ci file to download the older transition files. For now, this will only work on Linux builds.