### PR TITLE
Better handling of EnergyPlus dependency

### DIFF
--- a/archetypal/__init__.py
+++ b/archetypal/__init__.py
@@ -12,8 +12,10 @@ ep_version = "8-9-0"
 
 # warn if a newer version of archetypal is available
 from outdated import warn_if_outdated
+from .utils import warn_if_not_compatible
 
 warn_if_outdated("archetypal", __version__)
+warn_if_not_compatible()
 
 from .utils import *
 from .simple_glazing import *

--- a/archetypal/__init__.py
+++ b/archetypal/__init__.py
@@ -7,8 +7,6 @@
 
 # Version of the package
 __version__ = "1.3.0"
-# Latest version of EnergyPlus compatible with archetypal
-ep_version = "8-9-0"
 
 # warn if a newer version of archetypal is available
 from outdated import warn_if_outdated

--- a/archetypal/cli.py
+++ b/archetypal/cli.py
@@ -40,6 +40,7 @@ class CliConfig(object):
         self.useful_idf_objects = settings.useful_idf_objects
         self.umitemplate = settings.umitemplate
         self.trnsys_default_folder = settings.trnsys_default_folder
+        self.ep_version = settings.ep_version
 
 
 pass_config = click.make_pass_decorator(CliConfig, ensure=True)
@@ -107,6 +108,12 @@ pass_config = click.make_pass_decorator(CliConfig, ensure=True)
     help="root folder of TRNSYS install",
     default=settings.trnsys_default_folder,
 )
+@click.option(
+    "--ep_version",
+    type=click.STRING,
+    default=settings.ep_version,
+    help='the EnergyPlus version to use. eg. "8-9-0"',
+)
 @pass_config
 def cli(
     cli_config,
@@ -121,6 +128,7 @@ def cli(
     log_name,
     log_filename,
     trnsys_default_folder,
+    ep_version,
 ):
     """archetypal: Retrieve, construct, simulate, convert and analyse building
     simulation templates
@@ -143,6 +151,7 @@ def cli(
         log_name (str): name of the logger.
         log_filename (str): name of the log file.
         trnsys_default_folder (str): root folder of TRNSYS install.
+        ep_version (str): EnergyPlus version to use. eg.: "8-9-0".
     """
     cli_config.data_folder = data_folder
     cli_config.logs_folder = logs_folder
@@ -155,6 +164,7 @@ def cli(
     cli_config.log_name = log_name
     cli_config.log_filename = log_filename
     cli_config.trnsys_default_folder = trnsys_default_folder
+    cli_config.ep_version = ep_version
     # apply new config params
     config(**cli_config.__dict__)
 
@@ -339,12 +349,6 @@ def convert(
     help="The name of the output json file",
 )
 @click.option(
-    "--ep-version",
-    type=click.STRING,
-    help="specify the version of EnergyPlus to use, eg.: '8-9-0'",
-    default="8-9-0",
-)
-@click.option(
     "--weather",
     "-w",
     type=click.Path(exists=True),
@@ -360,7 +364,7 @@ def convert(
     default=True,
     help="process each idf file on different cores",
 )
-def reduce(idf, name, ep_version, weather, parallel):
+def reduce(idf, name, weather, parallel):
     """Perform the model reduction and translate to an UMI template file.
 
     Args:
@@ -381,7 +385,7 @@ def reduce(idf, name, ep_version, weather, parallel):
                 verbose="v",
                 output_report="sql",
                 return_idf=False,
-                ep_version=ep_version,
+                ep_version=settings.ep_version,
             )
             for file in idf
         }
@@ -399,7 +403,7 @@ def reduce(idf, name, ep_version, weather, parallel):
             res[fn][0], res[fn][1] = run_eplus(
                 fn,
                 weather,
-                ep_version=ep_version,
+                ep_version=settings.ep_version,
                 output_report="sql",
                 prep_outputs=True,
                 annual=True,

--- a/archetypal/cli.py
+++ b/archetypal/cli.py
@@ -334,7 +334,7 @@ def convert(
     "-w",
     type=click.Path(exists=True),
     help="path to the EPW weather file",
-    default=archetypal.get_eplus_dire()
+    default=archetypal.get_eplus_dirs(archetypal.ep_version)
     / "WeatherData"
     / "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw",
 )

--- a/archetypal/cli.py
+++ b/archetypal/cli.py
@@ -7,14 +7,25 @@
 import os
 from collections import defaultdict
 
-import archetypal
 import click
-from archetypal import settings, cd, load_idf
+
+from archetypal import (
+    settings,
+    cd,
+    load_idf,
+    convert_idf_to_trnbuild,
+    get_eplus_dirs,
+    parallel_process,
+    run_eplus,
+    IDF,
+    UmiTemplate,
+    config,
+)
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
-class Config(object):
+class CliConfig(object):
     def __init__(self):
         self.data_folder = settings.data_folder
         self.logs_folder = settings.logs_folder
@@ -31,7 +42,7 @@ class Config(object):
         self.trnsys_default_folder = settings.trnsys_default_folder
 
 
-pass_config = click.make_pass_decorator(Config, ensure=True)
+pass_config = click.make_pass_decorator(CliConfig, ensure=True)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
@@ -98,7 +109,7 @@ pass_config = click.make_pass_decorator(Config, ensure=True)
 )
 @pass_config
 def cli(
-    config,
+    cli_config,
     data_folder,
     logs_folder,
     imgs_folder,
@@ -117,31 +128,35 @@ def cli(
     Visit archetypal.readthedocs.io for the online documentation
 
     Args:
-        config:
-        data_folder:
-        logs_folder:
-        imgs_folder:
-        cache_folder:
-        use_cache:
-        log_file:
-        log_console:
-        log_level:
-        log_name:
-        log_filename:
-        trnsys_default_folder:
+        cli_config: Package configuration. See :class:`CliConfig` for more details.
+        data_folder (str): where to save and load data files.
+        logs_folder (str): where to write the log files.
+        imgs_folder (str): where to save figures.
+        cache_folder (str): where to save the simluation results.
+        use_cache (bool): if True, use a local cache to save/retrieve many of
+            archetypal outputs such as EnergyPlus simulation results. This can
+            save a lot of time by not calling the simulation and dataportal APIs
+            repetitively for the same requests.
+        log_file (bool): if true, save log output to a log file in logs_folder.
+        log_console (bool): if true, print log output to the console.
+        log_level (int): one of the logger.level constants.
+        log_name (str): name of the logger.
+        log_filename (str): name of the log file.
+        trnsys_default_folder (str): root folder of TRNSYS install.
     """
-    config.data_folder = data_folder
-    config.logs_folder = logs_folder
-    config.imgs_folder = imgs_folder
-    config.cache_folder = cache_folder
-    config.use_cache = use_cache
-    config.log_file = log_file
-    config.log_console = log_console
-    config.log_level = log_level
-    config.log_name = log_name
-    config.log_filename = log_filename
-    config.trnsys_default_folder = trnsys_default_folder
-    archetypal.config(**config.__dict__)
+    cli_config.data_folder = data_folder
+    cli_config.logs_folder = logs_folder
+    cli_config.imgs_folder = imgs_folder
+    cli_config.cache_folder = cache_folder
+    cli_config.use_cache = use_cache
+    cli_config.log_file = log_file
+    cli_config.log_console = log_console
+    cli_config.log_level = log_level
+    cli_config.log_name = log_name
+    cli_config.log_filename = log_filename
+    cli_config.trnsys_default_folder = trnsys_default_folder
+    # apply new config params
+    config(**cli_config.__dict__)
 
 
 @cli.command()
@@ -279,7 +294,7 @@ def convert(
         "tolerance": tolerance,
     }
     with cd(output_folder):
-        paths = archetypal.convert_idf_to_trnbuild(
+        paths = convert_idf_to_trnbuild(
             idf_file,
             window_lib,
             return_idf,
@@ -334,7 +349,7 @@ def convert(
     "-w",
     type=click.Path(exists=True),
     help="path to the EPW weather file",
-    default=archetypal.get_eplus_dirs(archetypal.ep_version)
+    default=get_eplus_dirs(settings.ep_version)
     / "WeatherData"
     / "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw",
 )
@@ -370,7 +385,7 @@ def reduce(idf, name, ep_version, weather, parallel):
             )
             for file in idf
         }
-        res = archetypal.parallel_process(rundict, archetypal.run_eplus)
+        res = parallel_process(rundict, run_eplus)
         loaded_idf = {}
         for key, sql in res.items():
             loaded_idf[key] = {}
@@ -381,7 +396,7 @@ def reduce(idf, name, ep_version, weather, parallel):
         # else, run sequentially
         res = defaultdict(dict)
         for fn in idf:
-            res[fn][0], res[fn][1] = archetypal.run_eplus(
+            res[fn][0], res[fn][1] = run_eplus(
                 fn,
                 weather,
                 ep_version=ep_version,
@@ -399,16 +414,8 @@ def reduce(idf, name, ep_version, weather, parallel):
         sql = next(
             iter([value for key, value in fn.items() if isinstance(value, dict)])
         )
-        idf = next(
-            iter(
-                [
-                    value
-                    for key, value in fn.items()
-                    if isinstance(value, archetypal.IDF)
-                ]
-            )
-        )
+        idf = next(iter([value for key, value in fn.items() if isinstance(value, IDF)]))
         bts.append(BuildingTemplate.from_idf(idf, sql=sql, DataSource=idf.name))
 
-    template = archetypal.UmiTemplate(name=name, BuildingTemplates=bts)
+    template = UmiTemplate(name=name, BuildingTemplates=bts)
     print(template.to_json())

--- a/archetypal/dataportal.py
+++ b/archetypal/dataportal.py
@@ -18,6 +18,7 @@ import zipfile
 import pandas as pd
 import pycountry as pycountry
 import requests
+
 from archetypal import log, settings, make_str
 
 # scipy and sklearn are optional dependencies for faster nearest node search

--- a/archetypal/energydataframe.py
+++ b/archetypal/energydataframe.py
@@ -1,7 +1,8 @@
 import matplotlib.pyplot as plt
+from pandas import DataFrame, Series, DatetimeIndex
+
 from archetypal import EnergySeries, settings
 from archetypal.energyseries import plot_energyseries_map, save_and_show
-from pandas import DataFrame, Series, DatetimeIndex
 
 
 class EnergyDataFrame(DataFrame):

--- a/archetypal/energyseries.py
+++ b/archetypal/energyseries.py
@@ -5,15 +5,16 @@ import time
 import warnings
 from datetime import timedelta
 
-import archetypal
 import numpy as np
 import pandas as pd
 import tsam.timeseriesaggregation as tsam
-from archetypal import log, rmse, piecewise, settings
 from matplotlib import pyplot as plt, cm
 from matplotlib.colors import LightSource
 from pandas import Series, DataFrame, concat, MultiIndex, date_range
 from sklearn import preprocessing
+
+import archetypal
+from archetypal import log, rmse, piecewise, settings
 
 
 class EnergySeries(Series):

--- a/archetypal/idfclass.py
+++ b/archetypal/idfclass.py
@@ -25,8 +25,12 @@ import eppy
 import eppy.modeleditor
 import geomeppy
 import pandas as pd
+from eppy.EPlusInterfaceFunctions import parse_idd
+from eppy.easyopen import getiddfile
+from path import Path, tempdir
 
 import archetypal
+import archetypal.settings
 from archetypal import (
     log,
     settings,
@@ -37,9 +41,6 @@ from archetypal import (
     close_logger,
 )
 from archetypal.utils import _unpack_tuple
-from eppy.EPlusInterfaceFunctions import parse_idd
-from eppy.easyopen import getiddfile
-from path import Path, tempdir
 
 
 class IDF(geomeppy.IDF):
@@ -1592,7 +1593,7 @@ def run_eplus(
         ep_version = ep_version.replace(".", "-")
     else:
         # if no version is specified, take the package default version
-        ep_version = archetypal.ep_version
+        ep_version = archetypal.settings.ep_version
     eplus_file = idf_version_updater(
         upgraded_file(eplus_file, output_directory),
         to_version=ep_version,

--- a/archetypal/idfclass.py
+++ b/archetypal/idfclass.py
@@ -2267,13 +2267,17 @@ def idf_version_updater(idf_file, to_version=None, out_dir=None, simulname=None)
         if os.path.exists(iddfile):
             # if a E+ exists, means there is an E+ install that can be used
             if versionid == to_version:
-                return None
+                # if version of idf file is equal to intended version, copy file from
+                # temp transition folder into cache folder and return path
+                return idf_file.copy(out_dir / idf_file.basename())
             # might be an old version of E+
         elif tuple(map(int, doted_version.split("."))) < (8, 0):
             # the version is an old E+ version (< 8.0)
             iddfile = getoldiddfile(doted_version)
             if versionid == to_version:
-                return None
+                # if version of idf file is equal to intended version, copy file from
+                # temp transition folder into cache folder and return path
+                return idf_file.copy(out_dir / idf_file.basename())
         # use to_version
         if to_version is None:
             # What is the latest E+ installed version

--- a/archetypal/idfclass.py
+++ b/archetypal/idfclass.py
@@ -25,6 +25,8 @@ import eppy
 import eppy.modeleditor
 import geomeppy
 import pandas as pd
+
+import archetypal
 from archetypal import (
     log,
     settings,
@@ -1586,8 +1588,11 @@ def run_eplus(
 
     # <editor-fold desc="Upgrade the file version if needed">
     if ep_version:
-        # replace the dots with "-"
+        # if users specifies version, make sure dots are replaced with "-".
         ep_version = ep_version.replace(".", "-")
+    else:
+        # if no version is specified, take the package default version
+        ep_version = archetypal.ep_version
     eplus_file = idf_version_updater(
         upgraded_file(eplus_file, output_directory),
         to_version=ep_version,
@@ -2253,7 +2258,7 @@ def idf_version_updater(idf_file, to_version=None, out_dir=None, simulname=None)
             the simulname is the same. (default: None)
 
     Returns:
-        Path: The path of the transitioned idf file.
+        Path: The path of the new transitioned idf file.
     """
     if not out_dir.isdir():
         out_dir.makedirs_p()

--- a/archetypal/idfclass.py
+++ b/archetypal/idfclass.py
@@ -2265,12 +2265,15 @@ def idf_version_updater(idf_file, to_version=None, out_dir=None, simulname=None)
         doted_version = get_idf_version(idf_file, doted=True)
         iddfile = getiddfile(doted_version)
         if os.path.exists(iddfile):
-            # if a E+ exists, pass
-            pass
+            # if a E+ exists, means there is an E+ install that can be used
+            if versionid == to_version:
+                return None
             # might be an old version of E+
         elif tuple(map(int, doted_version.split("."))) < (8, 0):
-            # else if the version is an old E+ version (< 8.0)
+            # the version is an old E+ version (< 8.0)
             iddfile = getoldiddfile(doted_version)
+            if versionid == to_version:
+                return None
         # use to_version
         if to_version is None:
             # What is the latest E+ installed version
@@ -2323,11 +2326,13 @@ def idf_version_updater(idf_file, to_version=None, out_dir=None, simulname=None)
             "8-8-0": os.path.join(vupdater_path, "Transition-V8-8-0-to-V8-9-0"),
             "8-9-0": os.path.join(vupdater_path, "Transition-V8-9-0-to-V9-0-0"),
             "9-0-0": os.path.join(vupdater_path, "Transition-V9-0-0-to-V9-1-0"),
+            "9-1-0": os.path.join(vupdater_path, "Transition-V9-1-0-to-V9-2-0"),
         }
-        # store the directory we start in
-        cwd = os.getcwd()
+        # set directory to run transition executables
         run_dir = Path(os.path.dirname(trans_exec[versionid]))
 
+        # check the file version, if it corresponds to the latest version found on
+        # the machine, means its already upgraded to the correct version. Return it.
         if versionid == to_version:
             # if file version and to_veersion are the same, we don't need to
             # perform transition
@@ -2339,6 +2344,7 @@ def idf_version_updater(idf_file, to_version=None, out_dir=None, simulname=None)
             idf_file = Path(idf_file.copy(out_dir))
             return idf_file
 
+        # Otherwise,
         # build a list of command line arguments
         with cd(run_dir):
             transitions = [

--- a/archetypal/plot.py
+++ b/archetypal/plot.py
@@ -20,9 +20,10 @@ import warnings
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from archetypal import settings, log
 from matplotlib import cm
 from matplotlib.colors import LightSource
+
+from archetypal import settings, log
 
 
 def save_and_show(

--- a/archetypal/reportdata.py
+++ b/archetypal/reportdata.py
@@ -5,8 +5,9 @@ from sqlite3 import OperationalError
 
 import numpy as np
 import pandas as pd
-from archetypal import log, EnergySeries
 from path import Path
+
+from archetypal import log, EnergySeries
 
 
 class ReportData(pd.DataFrame):

--- a/archetypal/schedule.py
+++ b/archetypal/schedule.py
@@ -10,12 +10,13 @@ import logging as lg
 import tempfile
 from datetime import datetime, timedelta
 
-import archetypal
 import numpy as np
 import pandas as pd
-from archetypal import log, settings
 from eppy.bunch_subclass import EpBunch
 from path import Path
+
+import archetypal
+from archetypal import log, settings
 
 
 class Schedule(object):

--- a/archetypal/settings.py
+++ b/archetypal/settings.py
@@ -7,10 +7,11 @@
 
 import logging as lg
 
-# locations to save data, logs, images, and cache
-import archetypal
 import pint
 from path import Path
+
+# locations to save data, logs, images, and cache
+import archetypal
 
 data_folder = Path("data")
 logs_folder = Path("logs")
@@ -169,3 +170,6 @@ class ZoneWeight(object):
 
 
 zone_weight = ZoneWeight(n=0)
+
+# Latest version of EnergyPlus compatible with archetypal
+ep_version = "8-9-0"

--- a/archetypal/simple_glazing.py
+++ b/archetypal/simple_glazing.py
@@ -9,6 +9,7 @@ import logging as lg
 import math
 
 import numpy as np
+
 from archetypal import log
 
 

--- a/archetypal/tabulardata.py
+++ b/archetypal/tabulardata.py
@@ -3,6 +3,7 @@ import time
 
 import numpy as np
 import pandas as pd
+
 from archetypal import log
 
 

--- a/archetypal/template/building_template.py
+++ b/archetypal/template/building_template.py
@@ -817,7 +817,7 @@ class ZoneGraph(networkx.Graph):
 
                 groups = set(networkx.get_node_attributes(G, color_nodes).values())
                 mapping = dict(zip(sorted(groups), count()))
-                colors = [mapping[G.node[n][color_nodes]] for n in tree.nodes]
+                colors = [mapping[G.nodes[n][color_nodes]] for n in tree.nodes]
                 colors = [discrete_cmap(len(groups), cmap).colors[i] for i in colors]
 
             paths_ = []

--- a/archetypal/trnsys.py
+++ b/archetypal/trnsys.py
@@ -16,6 +16,10 @@ import time
 
 import numpy as np
 import pandas as pd
+from geomeppy.geom.polygons import Polygon3D
+from path import Path
+from tqdm import tqdm
+
 from archetypal import (
     log,
     settings,
@@ -27,9 +31,6 @@ from archetypal import (
     load_idf_object_from_cache,
     hash_file,
 )
-from geomeppy.geom.polygons import Polygon3D
-from path import Path
-from tqdm import tqdm
 
 
 def convert_idf_to_trnbuild(

--- a/archetypal/umi_template.py
+++ b/archetypal/umi_template.py
@@ -4,6 +4,7 @@ import os
 from collections import OrderedDict
 
 import numpy as np
+
 from archetypal import (
     load_idf,
     BuildingTemplate,

--- a/archetypal/utils.py
+++ b/archetypal/utils.py
@@ -241,6 +241,14 @@ def get_logger(level=None, name=None, filename=None, log_dir=None):
 
 
 def close_logger(logger=None, level=None, name=None, filename=None, log_dir=None):
+    """
+    Args:
+        logger:
+        level:
+        name:
+        filename:
+        log_dir:
+    """
     if not logger:
         # try get logger by name
         logger = get_logger(level=level, name=name, filename=filename, log_dir=log_dir)
@@ -552,6 +560,7 @@ def weighted_mean(series, df, weighting_variable):
 def top(series, df, weighting_variable):
     """Compute the highest ranked value weighted by some other variable.
     Implements
+
         :func:`pandas.DataFrame.nlargest`.
 
     Args:
@@ -666,6 +675,10 @@ class EnergyPlusProcessError(Error):
 
 @contextlib.contextmanager
 def cd(path):
+    """
+    Args:
+        path:
+    """
     log("initially inside {0}".format(os.getcwd()))
     CWD = os.getcwd()
 
@@ -822,7 +835,6 @@ def float_round(num, n):
 
     Returns:
         num (float): a float rounded number
-
     """
     num = float(num)
     num = round(num, n)
@@ -832,10 +844,10 @@ def float_round(num, n):
 def get_eplus_dirs(version=ep_version):
     """Returns EnergyPlus root folder for a specific version.
 
+    Returns (Path): The folder path.
+
     Args:
         version (str): Version number in the form "8-9-0" to search for.
-
-    Returns (Path): The folder path.
     """
     from eppy.runner.run_functions import install_paths
 
@@ -845,8 +857,10 @@ def get_eplus_dirs(version=ep_version):
 
 
 def warn_if_not_compatible():
-    """Checks if an EnergyPlus install is detected. If the latest version detected
-    is higher than the one specified by archetypal, a warning is also raised."""
+    """Checks if an EnergyPlus install is detected. If the latest version
+    detected is higher than the one specified by archetypal, a warning is also
+    raised.
+    """
     eplus_homes = get_eplus_basedirs()
 
     if not eplus_homes:
@@ -920,8 +934,12 @@ def timeit(method):
 
 
 def lcm(x, y):
-    """This function takes two
-   integers and returns the L.C.M."""
+    """This function takes two integers and returns the L.C.M.
+
+    Args:
+        x:
+        y:
+    """
 
     # choose the greater number
     if x > y:

--- a/archetypal/utils.py
+++ b/archetypal/utils.py
@@ -28,9 +28,11 @@ from datetime import datetime, timedelta
 
 import numpy as np
 import pandas as pd
-from archetypal import settings, ep_version
 from pandas.io.json import json_normalize
 from path import Path
+
+from archetypal import settings
+from archetypal.settings import ep_version
 
 
 def config(
@@ -48,26 +50,30 @@ def config(
     umitemplate=settings.umitemplate,
     trnsys_default_folder=settings.trnsys_default_folder,
     default_weight_factor="area",
+    ep_version=settings.ep_version,
 ):
-    """Configurations
+    """Package configurations. Call this method at the beginning of script or at the
+    top of an interactive python environment to set package-wide settings.
 
     Args:
-        data_folder (str): where to save and load data files
-        logs_folder (str): where to write the log files
-        imgs_folder (str): where to save figures
-        cache_folder (str): where to save the simluation results
+        data_folder (str): where to save and load data files.
+        logs_folder (str): where to write the log files.
+        imgs_folder (str): where to save figures.
+        cache_folder (str): where to save the simluation results.
         use_cache (bool): if True, use a local cache to save/retrieve many of
             archetypal outputs such as EnergyPlus simulation results. This can
             save a lot of time by not calling the simulation and dataportal APIs
             repetitively for the same requests.
-        log_file (bool): if true, save log output to a log file in logs_folder
-        log_console (bool): if true, print log output to the console
-        log_level (int): one of the logger.level constants
-        log_name (str): name of the logger
-        log_filename (str): name of the log file
-        useful_idf_objects (list): a list of useful idf objects
-        umitemplate (str): where the umitemplate is located
-        trnsys_default_folder (str): root folder of TRNSYS install
+        log_file (bool): if true, save log output to a log file in logs_folder.
+        log_console (bool): if true, print log output to the console.
+        log_level (int): one of the logger.level constants.
+        log_name (str): name of the logger.
+        log_filename (str): name of the log file.
+        useful_idf_objects (list): a list of useful idf objects.
+        umitemplate (str): where the umitemplate is located.
+        trnsys_default_folder (str): root folder of TRNSYS install.
+        default_weight_factor:
+        ep_version (str): EnergyPlus version to use. eg. "8-9-0".
 
     Returns:
         None
@@ -87,10 +93,18 @@ def config(
     settings.umitemplate = umitemplate
     settings.trnsys_default_folder = validate_trnsys_folder(trnsys_default_folder)
     settings.zone_weight.set_weigth_attr(default_weight_factor)
+    settings.ep_version = validate_epversion(ep_version)
 
     # if logging is turned on, log that we are configured
     if settings.log_file or settings.log_console:
         log("Configured archetypal")
+
+
+def validate_epversion(ep_version):
+    """Validates the ep_version form"""
+    if "." in ep_version:
+        raise NameError('Enter the EnergyPlus version in the form "8-9-0"')
+    return ep_version
 
 
 def validate_trnsys_folder(trnsys_default_folder):

--- a/docs/examples/parallel_process.py
+++ b/docs/examples/parallel_process.py
@@ -4,7 +4,7 @@ from path import Path
 from archetypal import config, run_eplus
 from archetypal import parallel_process
 
-config(use_cache=True, log_console=True, cache_folder="../../tests/.temp/cache")
+config(cache_folder="../../tests/.temp/cache", use_cache=True, log_console=True)
 
 
 def main():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,13 +60,13 @@ def idf_source(request):
 @pytest.fixture(scope="session")
 def config():
     ar.config(
-        log_console=True,
-        log_file=True,
-        use_cache=True,
         data_folder="tests/.temp/data",
         logs_folder="tests/.temp/logs",
         imgs_folder="tests/.temp/imgs",
         cache_folder="tests/.temp/cache",
+        use_cache=True,
+        log_file=True,
+        log_console=True,
         umitemplate="tests/input_data/umi_samples" "/BostonTemplateLibrary_2.json",
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,14 +12,10 @@ class TestCli:
     def test_reduce(self, config):
         """Tests the 'reduce' method"""
         runner = CliRunner()
-        examples = get_eplus_dirs(ep_version) / "ExampleFiles"
-        necb = Path("tests/input_data/necb")
-        test_file = examples / "2ZoneDataCenterHVAC_wEconomizer.idf"
         test_file_list = [
             "tests/input_data/umi_samples/B_Off_0.idf",
             "tests/input_data/umi_samples/B_Res_0_Masonry.idf",
         ]
-        test_files = necb.glob("*Retail*.idf")
         result = runner.invoke(
             cli,
             [
@@ -33,6 +29,8 @@ class TestCli:
                 "--logs-folder",
                 "tests/.temp/logs",
                 "--log-console",
+                "--ep_version",
+                "8-9-0",
                 "reduce",
                 "-n",
                 "Retail",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from click.testing import CliRunner
 
-from archetypal import get_eplus_dirs, ep_version
+from archetypal import get_eplus_dirs
+from archetypal.settings import ep_version
 from archetypal.cli import cli
 from path import Path
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 from click.testing import CliRunner
 
-from archetypal import get_eplus_dire
+from archetypal import get_eplus_dirs, ep_version
 from archetypal.cli import cli
 from path import Path
 
@@ -11,7 +11,7 @@ class TestCli:
     def test_reduce(self, config):
         """Tests the 'reduce' method"""
         runner = CliRunner()
-        examples = get_eplus_dire() / "ExampleFiles"
+        examples = get_eplus_dirs(ep_version) / "ExampleFiles"
         necb = Path("tests/input_data/necb")
         test_file = examples / "2ZoneDataCenterHVAC_wEconomizer.idf"
         test_file_list = [

--- a/tests/test_idf.py
+++ b/tests/test_idf.py
@@ -9,6 +9,7 @@ import matplotlib as mpl
 import pytest
 from path import Path
 
+import archetypal.settings
 from archetypal import EnergyPlusProcessError
 
 mpl.use("Agg")
@@ -76,7 +77,7 @@ def test_load_old(config):
 
 @pytest.mark.parametrize(
     "ep_version",
-    [ar.ep_version, None],
+    [archetypal.settings.ep_version, None],
     ids=["specific-ep-version", "no-specific-ep-version"],
 )
 def test_run_olderv(config, fresh_start, ep_version):

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -5,7 +5,7 @@ import pytest
 from path import Path
 
 import archetypal as ar
-from archetypal import get_eplus_dire, clear_cache
+from archetypal import get_eplus_dirs, clear_cache, ep_version
 
 
 @pytest.fixture(scope="session")
@@ -1687,7 +1687,7 @@ class TestWindowSetting:
             config:
             request:
         """
-        eplusdir = get_eplus_dire()
+        eplusdir = get_eplus_dirs(ar.ep_version)
         file = eplusdir / "ExampleFiles" / request.param
         w = "tests/input_data/CAN_PQ_Montreal.Intl.AP.716270_CWEC.epw"
         idf = ar.load_idf(file)
@@ -2069,7 +2069,7 @@ class TestZone:
 @pytest.fixture(scope="session")
 def bt():
     """A building template fixture used in subsequent tests"""
-    eplus_dir = get_eplus_dire()
+    eplus_dir = get_eplus_dirs(ar.ep_version)
     file = eplus_dir / "ExampleFiles" / "5ZoneCostEst.idf"
     w = next(iter((eplus_dir / "WeatherData").glob("*.epw")), None)
     file = ar.copy_file(file)

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2281,7 +2281,7 @@ class TestZoneGraph:
         """
         G.info()
 
-    def test_viewgraph2d(self, G):
+    def test_viewgraph2d(self, config, G):
         """test the visualization of the zonegraph in 2d
 
         Args:

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -5,7 +5,9 @@ import pytest
 from path import Path
 
 import archetypal as ar
-from archetypal import get_eplus_dirs, clear_cache, ep_version
+import archetypal.settings
+from archetypal import get_eplus_dirs, clear_cache
+from archetypal.settings import ep_version
 
 
 @pytest.fixture(scope="session")
@@ -1687,7 +1689,7 @@ class TestWindowSetting:
             config:
             request:
         """
-        eplusdir = get_eplus_dirs(ar.ep_version)
+        eplusdir = get_eplus_dirs(archetypal.settings.ep_version)
         file = eplusdir / "ExampleFiles" / request.param
         w = "tests/input_data/CAN_PQ_Montreal.Intl.AP.716270_CWEC.epw"
         idf = ar.load_idf(file)
@@ -2069,7 +2071,7 @@ class TestZone:
 @pytest.fixture(scope="session")
 def bt():
     """A building template fixture used in subsequent tests"""
-    eplus_dir = get_eplus_dirs(ar.ep_version)
+    eplus_dir = get_eplus_dirs(archetypal.settings.ep_version)
     file = eplus_dir / "ExampleFiles" / "5ZoneCostEst.idf"
     w = next(iter((eplus_dir / "WeatherData").glob("*.epw")), None)
     file = ar.copy_file(file)


### PR DESCRIPTION
This pull request adds better handling of the EnergyPlus dependency. A new function looks for possible EnergyPlus install folders, during package import, and warns if none are found. If more than one is found (different EnergyPlus versions), a warning informs users that they should specify the version they wish to use in archetypal such as run_eplus().