### PR TITLE
Documentation

### DIFF
--- a/docs/converter_bui.rst
+++ b/docs/converter_bui.rst
@@ -33,6 +33,11 @@ BUI file
 
 Internal thermal gains such as “people”, “lights” and “equipment” are translated from the IDF file to the BUI file.
 
+4. Conditioning
+
+Heating and cooling demands are translated from the IDF file to the BUI file such as power per floor area (W/m²) and a temperature setpoint.
+The temperature setpoint is the setpoint at the peak time for heating (or cooling).
+
 Methodology
 -----------
 


### PR DESCRIPTION
Creates documentation for:
1) BUI converter (how to use it, details kwargs, etc)
2) Using archetypal as simulation environment (e.g. run_eplus)