### PR TITLE
Added daylighting Dimming Types for Continuous and Stepped Daylighting:Controls

### DIFF
--- a/archetypal/template/load.py
+++ b/archetypal/template/load.py
@@ -41,31 +41,25 @@ class ZoneLoad(UmiBase, metaclass=Unique):
         """Initialize a new ZoneLoad object
 
         Args:
-            *args:
-            DimmingType (str): Different types to dim the lighting to respect
-                the IlluminanceTraget and taking into account the daylight
-                illuminance: * If `Continuous` : the overhead lights dim
-                continuously and
-
-                    linearly from (maximum electric power, maximum light output)
-                    to (minimum electric power, minimum light output) as the
-                    daylight illuminance increases. The lights stay on at the
-                    minimum point with further increase in the daylight
-                    illuminance
-
-                * If `Stepped`: the electric power input and light output vary
-                      in discrete, equally spaced steps
-
-                * If `Off`: Lights switch off completely when the minimum
-                      dimming point is reached
+            DimmingType (str): Different types to dim the lighting to respect the
+                IlluminanceTraget and taking into account the daylight illuminance:
+                    - If `Continuous`, the overhead lights dim continuously and linearly
+                      from (maximum electric power, maximum light output) to (minimum
+                      electric power, minimum light output) as the daylight illuminance
+                      increases. The lights stay on at the minimum point with further
+                      increase in the daylight illuminance.
+                    - If `Stepped`, the electric power input and light output vary
+                      in discrete, equally spaced steps.
+                    - If `Off`, Lights switch off completely when the minimum
+                      dimming point is reached.
             EquipmentAvailabilitySchedule (UmiSchedule): The name of
                 the schedule (Day | Week | Year) that modifies the design level
                 parameter for electric equipment.
             EquipmentPowerDensity (float): Equipment Power Density in the zone
-                (W/m²)
+                (W/m²).
             IlluminanceTarget (float): Number of lux to be respected in the zone
             LightingPowerDensity (float): Lighting Power Density in the zone
-                (W/m²)
+                (W/m²).
             LightsAvailabilitySchedule (UmiSchedule): The name of the
                 schedule (Day | Week | Year) that modifies the design level
                 parameter for lighting.
@@ -73,13 +67,13 @@ class ZoneLoad(UmiBase, metaclass=Unique):
                 (Day | Week | Year) that modifies the number of people parameter
                 for electric equipment.
             IsEquipmentOn (bool): If True, heat gains from Equipment are taken
-                into account for the zone's load calculation
+                into account for the zone's load calculation.
             IsLightingOn (bool): If True, heat gains from Lights are taken into
-                account for the zone's load calculation
+                account for the zone's load calculation.
             IsPeopleOn (bool): If True, heat gains from People are taken into
-                account for the zone's load calculation
-            PeopleDensity (float): Density of people in the zone (people/m²)
-            **kwargs:
+                account for the zone's load calculation.
+            PeopleDensity (float): Density of people in the zone (people/m²).
+            **kwargs: Other keywords passed to the parent constructor :class:`UmiBase`.
         """
         super(ZoneLoad, self).__init__(**kwargs)
         self.DimmingType = DimmingType

--- a/archetypal/template/load.py
+++ b/archetypal/template/load.py
@@ -430,8 +430,8 @@ def _resolve_illuminance_target(zone):
     else:
         # Else, there are no dimming controls => set to "Off".
         log(
-            "No illuminance target found for zone {}. Setting to default 300 "
+            "No illuminance target found for zone {}. Setting to default 500 "
             "lux".format(zone.Name),
             lg.DEBUG,
         )
-        return 300
+        return 500

--- a/archetypal/template/load.py
+++ b/archetypal/template/load.py
@@ -25,7 +25,6 @@ class ZoneLoad(UmiBase, metaclass=Unique):
 
     def __init__(
         self,
-        *args,
         DimmingType="Continuous",
         EquipmentAvailabilitySchedule=None,
         EquipmentPowerDensity=12,
@@ -82,7 +81,7 @@ class ZoneLoad(UmiBase, metaclass=Unique):
             PeopleDensity (float): Density of people in the zone (people/m²)
             **kwargs:
         """
-        super(ZoneLoad, self).__init__(*args, **kwargs)
+        super(ZoneLoad, self).__init__(**kwargs)
         self.DimmingType = DimmingType
         self.EquipmentAvailabilitySchedule = EquipmentAvailabilitySchedule
         self.EquipmentPowerDensity = EquipmentPowerDensity

--- a/archetypal/template/load.py
+++ b/archetypal/template/load.py
@@ -10,6 +10,7 @@ import collections
 from archetypal import log, timeit, settings
 from archetypal.template import UmiBase, Unique, UmiSchedule, UniqueName
 from archetypal.utils import reduce
+import logging as lg
 
 
 class ZoneLoad(UmiBase, metaclass=Unique):
@@ -36,7 +37,7 @@ class ZoneLoad(UmiBase, metaclass=Unique):
         IsLightingOn=True,
         IsPeopleOn=True,
         PeopleDensity=0.2,
-        **kwargs
+        **kwargs,
     ):
         """Initialize a new ZoneLoad object
 
@@ -180,8 +181,8 @@ class ZoneLoad(UmiBase, metaclass=Unique):
             zone (archetypal.template.zone.Zone): zone to gets information from
         """
 
-        # Get schedule index for different loads and creates ZoneLoad arguments
-        # Verifies if Equipment in zone
+        # Get schedule index for different loads and create ZoneLoad arguments
+        # Verify if Equipment in zone
         zone_index = zone.sql["Zones"][
             zone.sql["Zones"]["ZoneName"].str.contains(zone.Name.upper())
         ].index[0]
@@ -202,7 +203,7 @@ class ZoneLoad(UmiBase, metaclass=Unique):
             else:
                 EquipmentPowerDensity = (
                     nominal_elec["DesignLevel"].sum() + nominal_gas["DesignLevel"].sum()
-                ) / zone.area
+                ) / zone.area  # todo: Should nominal gas really be added to elec?
 
             sched_indexes = nominal_elec["ScheduleIndex"].values
             design_index = nominal_elec["DesignLevel"].index
@@ -210,11 +211,11 @@ class ZoneLoad(UmiBase, metaclass=Unique):
             for sched, design in zip(sched_indexes, design_index):
                 sched_name = zone.sql["Schedules"]["ScheduleName"][sched]
                 schedule = UmiSchedule(Name=sched_name, idf=zone.idf)
-                schedule.weights = nominal_elec["DesignLevel"][design]
+                schedule.combine_weight = nominal_elec["DesignLevel"][design]
                 list_sched.append(schedule)
 
             EquipmentAvailabilitySchedule = reduce(
-                UmiSchedule.combine, list_sched, weights="weights"
+                UmiSchedule.combine, list_sched, weights="combine_weight"
             )
         # Verifies if Lights in zone
         if zone.sql["NominalLighting"][
@@ -265,10 +266,10 @@ class ZoneLoad(UmiBase, metaclass=Unique):
         z_load = cls(
             Name=name,
             zone=zone,
-            DimmingType="Continuous",
+            DimmingType=_resolve_dimming_type(zone),
             EquipmentAvailabilitySchedule=EquipmentAvailabilitySchedule,
             EquipmentPowerDensity=EquipmentPowerDensity,
-            IlluminanceTarget=500,
+            IlluminanceTarget=_resolve_illuminance_target(zone),
             LightingPowerDensity=LightingPowerDensity,
             LightsAvailabilitySchedule=LightsAvailabilitySchedule,
             OccupancySchedule=OccupancySchedule,
@@ -359,3 +360,85 @@ class ZoneLoad(UmiBase, metaclass=Unique):
         new_obj._belongs_to_zone = self._belongs_to_zone
         new_obj._predecessors.extend(self.predecessors + other.predecessors)
         return new_obj
+
+
+def _resolve_dimming_type(zone):
+    """Resolves the dimming type for the Zone object"""
+    # First, retrieve the list of Daylighting objects for this zone. Uses the eppy
+    # `getreferingobjs` method.
+    ep_obj = zone._epbunch
+    possible_ctrls = ep_obj.getreferingobjs(
+        iddgroups=["Daylighting"], fields=["Zone_Name"]
+    )
+    # Then, if there are controls
+    if possible_ctrls:
+        # Filter only the "Daylighting:Controls"
+        ctrls = [
+            ctrl
+            for ctrl in possible_ctrls
+            if ctrl.key.upper() == "Daylighting:Controls".upper()
+        ]
+        ctrl_types = [ctrl["Lighting_Control_Type"] for ctrl in ctrls]
+
+        # There should only be one control per zone. A set of controls should return 1.
+        if len(set(ctrl_types)) == 1:
+            dimming_type = next(iter(set(ctrl_types)))
+            if dimming_type.lower() not in ["continuous", "stepped"]:
+                raise ValueError(
+                    f"A dimming type of type '{dimming_type}' for zone '{zone.Name}' is not yet supported in UMI"
+                )
+            else:
+                log(f"Dimming type for zone '{zone.Name}' set to '{dimming_type}'")
+                return dimming_type  # Return first element
+        else:
+            raise ValueError(
+                "Could not resolve more than one dimming types for Zone {}. "
+                "Make sure there is only one".format(zone.Name)
+            )
+    else:
+        # Else, there are no dimming controls => set to "Off".
+        log(
+            "No dimming type found for zone {}. Setting as Off".format(zone.Name),
+            lg.DEBUG,
+        )
+        return "Off"
+
+
+def _resolve_illuminance_target(zone):
+    """Resolves the illuminance target for the Zone object"""
+    # First, retrieve the list of Daylighting objects for this zone. Uses the eppy
+    # `getreferingobjs` method.
+    ep_obj = zone._epbunch
+    possible_ctrls = ep_obj.getreferingobjs(
+        iddgroups=["Daylighting"], fields=["Zone_Name"]
+    )
+    # Then, if there are controls
+    if possible_ctrls:
+        # Filter only the "Daylighting:Controls"
+        ctrls = [
+            ctrl
+            for ctrl in possible_ctrls
+            if ctrl.key.upper() == "Daylighting:Controls".upper()
+        ]
+        ctrl_types = [
+            ctrl["Illuminance_Setpoint_at_Reference_Point_1"] for ctrl in ctrls
+        ]
+
+        # There should only be one control per zone. A set of controls should return 1.
+        if len(set(ctrl_types)) == 1:
+            dimming_type = next(iter(set(ctrl_types)))
+            log(f"Illuminance target for zone '{zone.Name}' set to '{dimming_type}'")
+            return float(dimming_type)  # Return first element
+        else:
+            raise ValueError(
+                "Could not resolve more than one illuminance targets for Zone {}. "
+                "Make sure there is only one".format(zone.Name)
+            )
+    else:
+        # Else, there are no dimming controls => set to "Off".
+        log(
+            "No illuminance target found for zone {}. Setting to default 300 "
+            "lux".format(zone.Name),
+            lg.DEBUG,
+        )
+        return 300

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1419,7 +1419,7 @@ class TestZoneConditioning:
         ]
         cond_to_json = cond_json[0].to_json()
 
-    def test_hash_eq_zone_cond(self, small_idf):
+    def test_hash_eq_zone_cond(self, zoneConditioningtests):
         """Test equality and hashing of :class:`ZoneConditioning`
 
         Args:
@@ -1428,7 +1428,7 @@ class TestZoneConditioning:
         from archetypal.template import ZoneConditioning, Zone
         from copy import copy
 
-        idf, sql = small_idf
+        idf, sql, idf_name = zoneConditioningtests
         clear_cache()
         zone_ep = idf.idfobjects["ZONE"][0]
         zone = Zone.from_zone_epbunch(zone_ep, sql=sql)
@@ -1831,13 +1831,11 @@ class TestWindowSetting:
         idf, sql = small_idf
         idf2, sql2 = other_idf
         zone = idf.idfobjects["ZONE"][0]
-        iterator = iter([win for surf in zone.zonesurfaces for win in
-                         surf.subsurfaces])
+        iterator = iter([win for surf in zone.zonesurfaces for win in surf.subsurfaces])
         surface = next(iterator, None)
         window_1 = WindowSetting.from_surface(surface)
         zone = idf2.idfobjects["ZONE"][0]
-        iterator = iter([win for surf in zone.zonesurfaces for win in
-                         surf.subsurfaces])
+        iterator = iter([win for surf in zone.zonesurfaces for win in surf.subsurfaces])
         surface = next(iterator)
         window_2 = WindowSetting.from_surface(surface)
 
@@ -1855,14 +1853,12 @@ class TestWindowSetting:
         idf, sql = small_idf
         idf2, sql2 = other_idf
         zone = idf.idfobjects["ZONE"][0]
-        iterator = iter([win for surf in zone.zonesurfaces for win in
-                         surf.subsurfaces])
+        iterator = iter([win for surf in zone.zonesurfaces for win in surf.subsurfaces])
         surface = next(iterator, None)
         window_1 = WindowSetting.from_surface(surface)
         id_ = window_1.id
         zone = idf2.idfobjects["ZONE"][0]
-        iterator = iter([win for surf in zone.zonesurfaces for win in
-                         surf.subsurfaces])
+        iterator = iter([win for surf in zone.zonesurfaces for win in surf.subsurfaces])
         surface = next(iterator, None)
         window_2 = WindowSetting.from_surface(surface)
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -25,7 +25,7 @@ def small_idf(config):
         output_report="sql",
         prep_outputs=True,
         annual=False,
-        design_day=False,
+        design_day=False,  # This idf model cannot do DesignDay
         verbose="v",
     )
     yield idf, sql
@@ -46,7 +46,7 @@ def other_idf(config):
         output_report="sql",
         prep_outputs=True,
         annual=False,
-        design_day=False,
+        design_day=False,  # This idf model cannot do DesignDay
         verbose="v",
     )
     yield idf, sql


### PR DESCRIPTION
Zones with referenced `Daylighting:Controls` objects are now supported. For example, a zone with the object:
<details><summary>Daylighting:Controls</summary>
<p>

```
Daylighting:Controls,
    Zone 1_DaylCtrl,          !- Name
    Zone 1,                   !- Zone Name
    SplitFlux,                !- Daylighting Method
    MidriseApartment-3B_APT_LIGHT_SCH_Year,    !- Availability Schedule Name
    Continuous,               !- Lighting Control Type
    0.1,                      !- Minimum Input Power Fraction for Continuous or ContinuousOff Dimming Control
    0.1,                      !- Minimum Light Output Fraction for Continuous or ContinuousOff Dimming Control
    3,                        !- Number of Stepped Control Steps
    1,                        !- Probability Lighting will be Reset When Needed in Manual Stepped Control
    ,                         !- Glare Calculation Daylighting Reference Point Name
    ,                         !- Glare Calculation Azimuth Angle of View Direction Clockwise from Zone yAxis
    22,                       !- Maximum Allowable Discomfort Glare Index
    ,                         !- DElight Gridding Resolution
    Zone 1_DaylCtrlRefPt1,    !- Daylighting Reference Point 1 Name
    1,                        !- Fraction of Zone Controlled by Reference Point 1
    300;                      !- Illuminance Setpoint at Reference Point 1
```

</p>
</details>
can is now detected and handled