### PR TITLE
Allows to create Umi schedule from json

### DIFF
--- a/archetypal/idfclass.py
+++ b/archetypal/idfclass.py
@@ -15,6 +15,7 @@ import os
 import platform
 import subprocess
 import time
+import tempfile
 from collections import defaultdict, OrderedDict
 from itertools import compress
 from math import isclose
@@ -2549,6 +2550,42 @@ def getoldiddfile(versionid):
     eplusfolder = os.path.dirname(eplus_exe)
     iddfile = "{}/bin/Energy+.idd".format(eplusfolder)
     return iddfile
+
+
+def _create_idf_object(version):
+    """ Creates an IDF object with only the VERSION of the IDF
+
+    Args:
+        version (str): Version of the IDF to use in the form "9-2-0"
+            (with hyphen, no point)
+
+    Returns:
+        An archetypal.IDF object
+
+    """
+    # Create a new idf object and add the schedule to it.
+    idftxt = "VERSION, {};".format(
+        version.replace("-", ".")[0:3]
+    )  # Not an empty string. has just the
+    # version number
+    # we can make a file handle of a string
+    if not Path(settings.cache_folder).exists():
+        Path(settings.cache_folder).mkdir_p()
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix="_" + version + ".idf",
+        prefix="temp_",
+        dir=settings.cache_folder,
+        delete=False,
+    ) as file:
+        file.write(idftxt)
+    # initialize the IDF object with the file handle
+    from eppy.easyopen import easyopen
+
+    idf_scratch = easyopen(file.name)
+    idf_scratch.__class__ = archetypal.IDF
+
+    return idf_scratch
 
 
 if __name__ == "__main__":

--- a/archetypal/schedule.py
+++ b/archetypal/schedule.py
@@ -206,9 +206,12 @@ class Schedule(object):
             # not have a Schedule_Type_Limits_Name field
             return "", "", "", ""
         else:
-            lower_limit, upper_limit, numeric_type, unit_type = self.idf.get_schedule_type_limits_data_by_name(
-                schedule_limit_name
-            )
+            (
+                lower_limit,
+                upper_limit,
+                numeric_type,
+                unit_type,
+            ) = self.idf.get_schedule_type_limits_data_by_name(schedule_limit_name)
 
             self.unit = unit_type
             if self.unit == "unknown":
@@ -273,9 +276,12 @@ class Schedule(object):
             epbunch (EpBunch): The schedule EpBunch object.
         """
 
-        lower_limit, upper_limit, numeric_type, unit_type = self.get_schedule_type_limits_data(
-            epbunch.Name
-        )
+        (
+            lower_limit,
+            upper_limit,
+            numeric_type,
+            unit_type,
+        ) = self.get_schedule_type_limits_data(epbunch.Name)
 
         number_of_day_sch = int((len(epbunch.fieldvalues) - 3) / 2)
 
@@ -424,9 +430,12 @@ class Schedule(object):
         Args:
             epbunch (EpBunch): The schedule epbunch object.
         """
-        lower_limit, upper_limit, numeric_type, unit_type = self.get_schedule_type_limits_data(
-            epbunch.Name
-        )
+        (
+            lower_limit,
+            upper_limit,
+            numeric_type,
+            unit_type,
+        ) = self.get_schedule_type_limits_data(epbunch.Name)
 
         hourly_values = np.arange(8760)
         value = float(epbunch["Hourly_Value"])

--- a/archetypal/schedule.py
+++ b/archetypal/schedule.py
@@ -18,6 +18,7 @@ from path import Path
 
 import archetypal
 from archetypal import log, settings
+from archetypal.idfclass import _create_idf_object
 
 
 class Schedule(object):
@@ -58,6 +59,8 @@ class Schedule(object):
         except:
             pass
         self.strict = strict
+        if not isinstance(idf, archetypal.IDF):
+            idf = _create_idf_object(settings.ep_version)
         self.idf = idf
         self.Name = Name
         self.startDayOfTheWeek = self.get_sdow(start_day_of_the_week)

--- a/archetypal/template/schedule.py
+++ b/archetypal/template/schedule.py
@@ -144,8 +144,10 @@ class UmiSchedule(Schedule, UmiBase, metaclass=Unique):
             )
         elif isinstance(quantity, dict):
             new_values = np.average(
-                [self.all_values * quantity[self.Name], other.all_values * quantity[
-                    other.Name]],
+                [
+                    self.all_values * quantity[self.Name],
+                    other.all_values * quantity[other.Name],
+                ],
                 axis=0,
                 weights=weights,
             )

--- a/archetypal/template/umi_base.py
+++ b/archetypal/template/umi_base.py
@@ -10,11 +10,13 @@ import logging as lg
 import math
 import random
 import re
+import archetypal
 
 import numpy as np
 
-from archetypal import log
+from archetypal import log, settings
 from archetypal.utils import lcm
+from archetypal.idfclass import _create_idf_object
 
 
 class Unique(type):
@@ -107,6 +109,8 @@ class UmiBase(object):
         """
         super(UmiBase, self).__init__()
         self.Name = Name
+        if not isinstance(idf, archetypal.IDF):
+            idf = _create_idf_object(settings.ep_version)
         self.idf = idf
         self.sql = sql
         self.Category = Category

--- a/archetypal/template/window.py
+++ b/archetypal/template/window.py
@@ -57,7 +57,7 @@ class WindowConstruction(UmiBase, metaclass=Unique):
         self.AssemblyEnergy = AssemblyEnergy
         self.AssemblyCost = AssemblyCost
         self.AssemblyCarbon = AssemblyCarbon
-        self.Layers = None
+        self.Layers = kwargs.get("Layers", None)
 
     def __hash__(self):
         return hash((self.__class__.__name__, self.Name, self.DataSource))

--- a/docs/creating_umi_template.rst
+++ b/docs/creating_umi_template.rst
@@ -228,6 +228,255 @@ examples will be shown for each object.
           # List of StructureDefinition objects (needed for Umi template creation)
           StructureDefinitions = [struct_definition]
 
+3. Defining schedules
+
+  Creating Umi template objects to define schedules (e.g. `DaySchedule`).
+
+    - Day schedules
+
+      Here are all the parameters and their default values for an
+      DaySchedule object (see DaySchedule_ doc for more information)
+
+      .. code-block:: python
+
+        def __init__(
+        Name=None,
+        idf=None,
+        start_day_of_the_week=0,
+        strict=False,
+        base_year=2018,
+        schType=None,
+        schTypeLimitsName=None,
+        values=None,
+        **kwargs)
+
+      Example of DaySchedule objects:
+
+        .. code-block:: python
+
+          # Always on
+          sch_d_on = ar.DaySchedule.from_values(
+          [1] * 24, Category="Day", schTypeLimitsName="Fractional", Name="AlwaysOn")
+          # Always off
+          sch_d_off = ar.DaySchedule.from_values(
+          [0] * 24, Category="Day", schTypeLimitsName="Fractional", Name="AlwaysOff")
+          # DHW
+          sch_d_dhw = ar.DaySchedule.from_values(
+          [0.3] * 24, Category="Day", schTypeLimitsName="Fractional", Name="DHW")
+          # Internal gains
+          sch_d_gains = ar.DaySchedule.from_values(
+          [0] * 6 + [0.5, 0.6, 0.7, 0.8, 0.9, 1] + [0.7] * 6 + [0.4] * 6,
+          Category="Day",
+          schTypeLimitsName="Fractional",
+          Name="Gains",)
+          # List of DaySchedule objects (needed for Umi template creation)
+          DaySchedules = [sch_d_on, sch_d_dhw, sch_d_gains, sch_d_off]
+
+    - Week schedules
+
+      Here are all the parameters and their default values for an
+      WeekSchedule object (see WeekSchedule_ doc for more information)
+
+      .. code-block:: python
+
+        def __init__(
+        Name=None,
+        idf=None,
+        start_day_of_the_week=0,
+        strict=False,
+        base_year=2018,
+        schType=None,
+        schTypeLimitsName=None,
+        values=None,
+        **kwargs)
+
+      Example of WeekSchedule objects:
+
+        .. code-block:: python
+
+          # WeekSchedules using DaySchedule objects
+          # Variable `days` needs a list of 7 dict,
+          # representing the 7 days of the week
+          sch_w_on = ar.WeekSchedule(
+          days=[
+            {"$ref": sch_d_on.id},
+            {"$ref": sch_d_on.id},
+            {"$ref": sch_d_on.id},
+            {"$ref": sch_d_on.id},
+            {"$ref": sch_d_on.id},
+            {"$ref": sch_d_on.id},
+            {"$ref": sch_d_on.id},],
+          Category="Week",
+          schTypeLimitsName="Fractional",
+          Name="AlwaysOn")
+          # Always off
+          sch_w_off = ar.WeekSchedule(
+          days=[
+            {"$ref": sch_d_off.id},
+            {"$ref": sch_d_off.id},
+            {"$ref": sch_d_off.id},
+            {"$ref": sch_d_off.id},
+            {"$ref": sch_d_off.id},
+            {"$ref": sch_d_off.id},
+            {"$ref": sch_d_off.id},],
+          Category="Week",
+          schTypeLimitsName="Fractional",
+          Name="AlwaysOff")
+          # DHW
+          sch_w_dhw = ar.WeekSchedule(
+          days=[
+            {"$ref": sch_d_dhw.id},
+            {"$ref": sch_d_dhw.id},
+            {"$ref": sch_d_dhw.id},
+            {"$ref": sch_d_dhw.id},
+            {"$ref": sch_d_dhw.id},
+            {"$ref": sch_d_dhw.id},
+            {"$ref": sch_d_dhw.id},],
+          Category="Week",
+          schTypeLimitsName="Fractional",
+          Name="DHW")
+          # Internal gains
+          sch_w_gains = ar.WeekSchedule(
+          days=[
+            {"$ref": sch_d_gains.id},
+            {"$ref": sch_d_gains.id},
+            {"$ref": sch_d_gains.id},
+            {"$ref": sch_d_gains.id},
+            {"$ref": sch_d_gains.id},
+            {"$ref": sch_d_gains.id},
+            {"$ref": sch_d_gains.id},],
+          Category="Week",
+          schTypeLimitsName="Fractional",
+          Name="Gains")
+          # List of WeekSchedule objects (needed for Umi template creation)
+          WeekSchedules = [sch_w_on, sch_w_off, sch_w_dhw, sch_w_gains]
+
+      WeekSchedule object can also be created from a dictionary.
+      For example, we create a WeekSchedule `AlwaysOn` from a dictionary and
+      using DaySchedule `AlwaysOn` objects:
+
+        .. code-block:: python
+
+          # Dict of a WeekSchedule (like it would be written in json file)
+          dict_w_on = {
+            "Category": "Week",
+            "Days": [
+                {"$ref": sch_d_on.id},
+                {"$ref": sch_d_off.id},
+                {"$ref": sch_d_on.id},
+                {"$ref": sch_d_off.id},
+                {"$ref": sch_d_on.id},
+                {"$ref": sch_d_off.id},
+                {"$ref": sch_d_on.id},
+            ],
+            "Type": "Fraction",
+            "Name": "OnOff_2"}
+          # Creates WeekSchedule from dict (from json)
+          sch_w_on = ar.WeekSchedule.from_json(**dict_w_on)
+
+    - Year schedules
+
+      Here are all the parameters and their default values for an
+      YearSchedule object (see YearSchedule_ doc for more information)
+
+      .. code-block:: python
+
+        def __init__(
+        Name=None,
+        idf=None,
+        start_day_of_the_week=0,
+        strict=False,
+        base_year=2018,
+        schType=None,
+        schTypeLimitsName=None,
+        values=None,
+        **kwargs)
+
+      YearSchedule are created from dictionaries.
+      For example, we create YearSchedules from dictionaries and
+      using WeekSchedule objects:
+
+        .. code-block:: python
+
+          # YearSchedules using DaySchedule objects
+          # Always on
+          dict_on = {
+          "Category": "Year",
+          "Parts": [
+            {
+                "FromDay": 1,
+                "FromMonth": 1,
+                "ToDay": 31,
+                "ToMonth": 12,
+                "Schedule": {"$ref": sch_w_on.id}
+            }],
+          "Type": "Fraction",
+          "Name": "AlwaysOn"}
+          sch_y_on = ar.YearSchedule.from_json(**dict_on)
+          # Always off
+          dict_off = {
+          "Category": "Year",
+          "Parts": [
+            {
+                "FromDay": 1,
+                "FromMonth": 1,
+                "ToDay": 31,
+                "ToMonth": 12,
+                "Schedule": {"$ref": sch_w_off.id}}],
+          "Type": "Fraction",
+          "Name": "AlwaysOff"}
+          sch_y_off = ar.YearSchedule.from_json(**dict_off)
+          # Year ON/OFF
+          dict_on_off = {
+          "Category": "Year",
+          "Parts": [
+            {
+                "FromDay": 1,
+                "FromMonth": 1,
+                "ToDay": 31,
+                "ToMonth": 5,
+                "Schedule": {"$ref": sch_w_on.id}
+            },
+            {
+                "FromDay": 1,
+                "FromMonth": 6,
+                "ToDay": 31,
+                "ToMonth": 12,
+                "Schedule": {"$ref": sch_w_off.id}
+            }
+                ],
+          "Type": "Fraction",
+          "Name": "ON_OFF"}
+          sch_y_on_off = ar.YearSchedule.from_json(**dict_on_off)
+          # DHW
+          dict_dhw = {
+          "Category": "Year",
+          "Parts": [
+            {
+                "FromDay": 1,
+                "FromMonth": 1,
+                "ToDay": 31,
+                "ToMonth": 12,
+                "Schedule": {"$ref": sch_w_dhw.id}}],
+          "Type": "Fraction",
+          "Name": "DHW"}
+          sch_y_dhw = ar.YearSchedule.from_json(**dict_dhw)
+          # Internal gains
+          dict_gains = {
+          "Category": "Year",
+          "Parts": [
+            {
+                "FromDay": 1,
+                "FromMonth": 1,
+                "ToDay": 31,
+                "ToMonth": 12,
+                "Schedule": {"$ref": sch_w_gains.id}}],
+          "Type": "Fraction",
+          "Name": "Gains"}
+          sch_y_gains = ar.YearSchedule.from_json(**dict_gains)
+          # List of YearSchedule objects (needed for Umi template creation)
+          YearSchedules = [sch_y_on, sch_y_off, sch_y_on_off, sch_y_dhw, sch_y_gains]
+
 .. _OpaqueMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.OpaqueMaterial.html
 .. _GlazingMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GlazingMaterial.html
 .. _GasMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GasMaterial.html
@@ -235,4 +484,6 @@ examples will be shown for each object.
 .. _WindowConstruction: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.WindowConstruction.html
 .. _StructureDefinition: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.StructureDefinition.html
 .. _MassRatio: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.MassRatio.html
-
+.. _DaySchedule: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.DaySchedule.html
+.. _WeekSchedule: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.WeekSchedule.html
+.. _YearSchedule: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.YearSchedule.html

--- a/docs/creating_umi_template.rst
+++ b/docs/creating_umi_template.rst
@@ -1,0 +1,60 @@
+Creating an Umi template
+------------------------
+
+The following sections explain how to create an Umi template using different
+modules available in `archetypal`
+The documentation will present how to create each Umi template object (e.g.
+`opaque materials`, `window settings`, `zone loads`, etc). Every inputs of
+each object will be presented with their default parameters, and simple
+examples will be shown for each object.
+
+1. Defining materials
+
+Creating Umi template objects to define materials (used as `Layers`
+in constructions).
+
+    - Opaque materials
+
+      Here are all the parameters and their default values for an
+      OpaqueMaterial object (see OpaqueMaterial_ doc for more information)
+
+      .. code-block:: python
+
+        def __init__(
+        Conductivity,
+        SpecificHeat,
+        SolarAbsorptance=0.7,
+        ThermalEmittance=0.9,
+        VisibleAbsorptance=0.7,
+        Roughness="Rough",
+        Cost=0,
+        Density=1,
+        MoistureDiffusionResistance=50,
+        EmbodiedCarbon=0.45,
+        EmbodiedEnergy=0,
+        TransportCarbon=0,
+        TransportDistance=0,
+        TransportEnergy=0,
+        SubstitutionRatePattern=None,
+        SubstitutionTimestep=20,
+        **kwargs)
+
+      Example of OpaqueMaterial objects:
+
+        .. code-block:: python
+
+          concrete = ar.OpaqueMaterial(Conductivity=0.5, SpecificHeat=800, Density=1500)
+          insulation = ar.OpaqueMaterial(Conductivity=0.04, SpecificHeat=1000, Density=30)
+          brick = ar.OpaqueMaterial(Conductivity=1, SpecificHeat=900, Density=1900)
+          plywood = ar.OpaqueMaterial(Conductivity=0.13, SpecificHeat=800, Density=540)
+          # List of OpaqueMaterial objects (needed for Umi template creation)
+          OpaqueMaterials = [concrete, insulation, brick, plywood]
+
+Blablablbalba
+
+
+.. _OpaqueMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.OpaqueMaterial.html
+
+
+
+

--- a/docs/creating_umi_template.rst
+++ b/docs/creating_umi_template.rst
@@ -477,6 +477,46 @@ examples will be shown for each object.
           # List of YearSchedule objects (needed for Umi template creation)
           YearSchedules = [sch_y_on, sch_y_off, sch_y_on_off, sch_y_dhw, sch_y_gains]
 
+4. Defining window settings
+
+  Creating Umi template objects to define window settings
+
+  Here are all the parameters and their default values for an
+  WindowSetting object (see WindowSetting_ doc for more information)
+
+  .. code-block:: python
+
+    def __init__(
+    Construction=None,
+    OperableArea=0.8,
+    AfnWindowAvailability=None,
+    AfnDischargeC=0.65,
+    AfnTempSetpoint=20,
+    IsVirtualPartition=False,
+    IsShadingSystemOn=False,
+    ShadingSystemAvailabilitySchedule=None,
+    ShadingSystemSetpoint=180,
+    ShadingSystemTransmittance=0.5,
+    ShadingSystemType=0,
+    Type=WindowType.External,
+    IsZoneMixingOn=False,
+    ZoneMixingAvailabilitySchedule=None,
+    ZoneMixingDeltaTemperature=2,
+    ZoneMixingFlowRate=0.001,
+    **kwargs)
+
+  Example of WindowSetting objects:
+
+  .. code-block:: python
+
+    window_setting = ar.WindowSetting(
+    Construction=window,
+    AfnWindowAvailability=sch_y_off,
+    ShadingSystemAvailabilitySchedule=sch_y_off,
+    ZoneMixingAvailabilitySchedule=sch_y_off)
+    # List of WindowSetting objects (needed for Umi template creation)
+    WindowSettings = [window_setting]
+
 .. _OpaqueMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.OpaqueMaterial.html
 .. _GlazingMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GlazingMaterial.html
 .. _GasMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GasMaterial.html
@@ -487,3 +527,4 @@ examples will be shown for each object.
 .. _DaySchedule: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.DaySchedule.html
 .. _WeekSchedule: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.WeekSchedule.html
 .. _YearSchedule: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.YearSchedule.html
+.. _WindowSetting: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.WindowSetting.html

--- a/docs/creating_umi_template.rst
+++ b/docs/creating_umi_template.rst
@@ -761,6 +761,35 @@ required inputs for each object.
         InternalMassConstruction=wall_int)
     # List of Zone objects (needed for Umi template creation)
     Zones = [perim, core]
+
+11. Defining building template
+
+  Creating Umi template objects to define building template
+
+  Here are all the parameters and their default values for an
+  BuildingTemplate object (see BuildingTemplate_ doc for more information)
+
+  .. code-block:: python
+
+    def __init__(
+        Core=None,
+        Perimeter=None,
+        Structure=None,
+        Windows=None,
+        Lifespan=60,
+        PartitionRatio=0.35,
+        DefaultWindowToWallRatio=0.4,
+        **kwargs)
+
+  Example of BuildingTemplate object:
+
+  .. code-block:: python
+
+    # BuildingTemplate using Zone, StructureDefinition and WindowSetting objects
+    building_template = ar.BuildingTemplate(
+        Core=core, Perimeter=perim, Structure=struct_definition, Windows=window_setting)
+    # List of BuildingTemplate objects (needed for Umi template creation)
+    BuildingTemplates = [building_template]
 .. _OpaqueMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.OpaqueMaterial.html
 .. _GlazingMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GlazingMaterial.html
 .. _GasMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GasMaterial.html
@@ -778,3 +807,4 @@ required inputs for each object.
 .. _ZoneConstructionSet: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.ZoneConstructionSet.html
 .. _ZoneLoad: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.ZoneLoad.html
 .. _Zone: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.Zone.html
+.. _BuildingTemplate: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.BuildingTemplate.html

--- a/docs/creating_umi_template.rst
+++ b/docs/creating_umi_template.rst
@@ -80,17 +80,17 @@ examples will be shown for each object.
         .. code-block:: python
 
           glass = ar.GlazingMaterial(
-          Density=2500,
-          Conductivity=1,
-          SolarTransmittance=0.7,
-          SolarReflectanceFront=0.5,
-          SolarReflectanceBack=0.5,
-          VisibleTransmittance=0.7,
-          VisibleReflectanceFront=0.5,
-          VisibleReflectanceBack=0.5,
-          IRTransmittance=0.7,
-          IREmissivityFront=0.5,
-          IREmissivityBack=0.5)
+            Density=2500,
+            Conductivity=1,
+            SolarTransmittance=0.7,
+            SolarReflectanceFront=0.5,
+            SolarReflectanceBack=0.5,
+            VisibleTransmittance=0.7,
+            VisibleReflectanceFront=0.5,
+            VisibleReflectanceBack=0.5,
+            IRTransmittance=0.7,
+            IREmissivityFront=0.5,
+            IREmissivityBack=0.5)
           # List of GlazingMaterial objects (needed for Umi template creation)
           GlazingMaterials = [glass]
 
@@ -146,25 +146,25 @@ examples will be shown for each object.
 
           # OpaqueConstruction using OpaqueMaterial objects
           wall_int = ar.OpaqueConstruction(
-          Layers=[plywood],
-          Surface_Type="Partition",
-          Outside_Boundary_Condition="Zone",
-          IsAdiabatic=True)
+            Layers=[plywood],
+            Surface_Type="Partition",
+            Outside_Boundary_Condition="Zone",
+            IsAdiabatic=True)
 
           wall_ext = ar.OpaqueConstruction(
-          Layers=[concrete, insulation, brick],
-          Surface_Type="Facade",
-          Outside_Boundary_Condition="Outdoors")
+            Layers=[concrete, insulation, brick],
+            Surface_Type="Facade",
+            Outside_Boundary_Condition="Outdoors")
 
           floor = ar.OpaqueConstruction(
-          Layers=[concrete, plywood],
-          Surface_Type="Ground",
-          Outside_Boundary_Condition="Zone")
+            Layers=[concrete, plywood],
+            Surface_Type="Ground",
+            Outside_Boundary_Condition="Zone")
 
           roof = ar.OpaqueConstruction(
-          Layers=[plywood, insulation, brick],
-          Surface_Type="Roof",
-          Outside_Boundary_Condition="Outdoors")
+            Layers=[plywood, insulation, brick],
+            Surface_Type="Roof",
+            Outside_Boundary_Condition="Outdoors")
           # List of OpaqueConstruction objects (needed for Umi template creation)
           OpaqueConstructions = [wall_int, wall_ext, floor, roof]
 
@@ -256,19 +256,19 @@ examples will be shown for each object.
 
           # Always on
           sch_d_on = ar.DaySchedule.from_values(
-          [1] * 24, Category="Day", schTypeLimitsName="Fractional", Name="AlwaysOn")
+            [1] * 24, Category="Day", schTypeLimitsName="Fractional", Name="AlwaysOn")
           # Always off
           sch_d_off = ar.DaySchedule.from_values(
-          [0] * 24, Category="Day", schTypeLimitsName="Fractional", Name="AlwaysOff")
+            [0] * 24, Category="Day", schTypeLimitsName="Fractional", Name="AlwaysOff")
           # DHW
           sch_d_dhw = ar.DaySchedule.from_values(
-          [0.3] * 24, Category="Day", schTypeLimitsName="Fractional", Name="DHW")
+            [0.3] * 24, Category="Day", schTypeLimitsName="Fractional", Name="DHW")
           # Internal gains
           sch_d_gains = ar.DaySchedule.from_values(
-          [0] * 6 + [0.5, 0.6, 0.7, 0.8, 0.9, 1] + [0.7] * 6 + [0.4] * 6,
-          Category="Day",
-          schTypeLimitsName="Fractional",
-          Name="Gains",)
+            [0] * 6 + [0.5, 0.6, 0.7, 0.8, 0.9, 1] + [0.7] * 6 + [0.4] * 6,
+            Category="Day",
+            schTypeLimitsName="Fractional",
+            Name="Gains",)
           # List of DaySchedule objects (needed for Umi template creation)
           DaySchedules = [sch_d_on, sch_d_dhw, sch_d_gains, sch_d_off]
 
@@ -298,56 +298,56 @@ examples will be shown for each object.
           # Variable `days` needs a list of 7 dict,
           # representing the 7 days of the week
           sch_w_on = ar.WeekSchedule(
-          days=[
-            {"$ref": sch_d_on.id},
-            {"$ref": sch_d_on.id},
-            {"$ref": sch_d_on.id},
-            {"$ref": sch_d_on.id},
-            {"$ref": sch_d_on.id},
-            {"$ref": sch_d_on.id},
-            {"$ref": sch_d_on.id},],
-          Category="Week",
-          schTypeLimitsName="Fractional",
-          Name="AlwaysOn")
+            days=[
+                {"$ref": sch_d_on.id},
+                {"$ref": sch_d_on.id},
+                {"$ref": sch_d_on.id},
+                {"$ref": sch_d_on.id},
+                {"$ref": sch_d_on.id},
+                {"$ref": sch_d_on.id},
+                {"$ref": sch_d_on.id},],
+            Category="Week",
+            schTypeLimitsName="Fractional",
+            Name="AlwaysOn")
           # Always off
           sch_w_off = ar.WeekSchedule(
-          days=[
-            {"$ref": sch_d_off.id},
-            {"$ref": sch_d_off.id},
-            {"$ref": sch_d_off.id},
-            {"$ref": sch_d_off.id},
-            {"$ref": sch_d_off.id},
-            {"$ref": sch_d_off.id},
-            {"$ref": sch_d_off.id},],
-          Category="Week",
-          schTypeLimitsName="Fractional",
-          Name="AlwaysOff")
+            days=[
+                {"$ref": sch_d_off.id},
+                {"$ref": sch_d_off.id},
+                {"$ref": sch_d_off.id},
+                {"$ref": sch_d_off.id},
+                {"$ref": sch_d_off.id},
+                {"$ref": sch_d_off.id},
+                {"$ref": sch_d_off.id},],
+            Category="Week",
+            schTypeLimitsName="Fractional",
+            Name="AlwaysOff")
           # DHW
           sch_w_dhw = ar.WeekSchedule(
-          days=[
-            {"$ref": sch_d_dhw.id},
-            {"$ref": sch_d_dhw.id},
-            {"$ref": sch_d_dhw.id},
-            {"$ref": sch_d_dhw.id},
-            {"$ref": sch_d_dhw.id},
-            {"$ref": sch_d_dhw.id},
-            {"$ref": sch_d_dhw.id},],
-          Category="Week",
-          schTypeLimitsName="Fractional",
-          Name="DHW")
+            days=[
+                {"$ref": sch_d_dhw.id},
+                {"$ref": sch_d_dhw.id},
+                {"$ref": sch_d_dhw.id},
+                {"$ref": sch_d_dhw.id},
+                {"$ref": sch_d_dhw.id},
+                {"$ref": sch_d_dhw.id},
+                {"$ref": sch_d_dhw.id},],
+            Category="Week",
+            schTypeLimitsName="Fractional",
+            Name="DHW")
           # Internal gains
           sch_w_gains = ar.WeekSchedule(
-          days=[
-            {"$ref": sch_d_gains.id},
-            {"$ref": sch_d_gains.id},
-            {"$ref": sch_d_gains.id},
-            {"$ref": sch_d_gains.id},
-            {"$ref": sch_d_gains.id},
-            {"$ref": sch_d_gains.id},
-            {"$ref": sch_d_gains.id},],
-          Category="Week",
-          schTypeLimitsName="Fractional",
-          Name="Gains")
+            days=[
+                {"$ref": sch_d_gains.id},
+                {"$ref": sch_d_gains.id},
+                {"$ref": sch_d_gains.id},
+                {"$ref": sch_d_gains.id},
+                {"$ref": sch_d_gains.id},
+                {"$ref": sch_d_gains.id},
+                {"$ref": sch_d_gains.id},],
+            Category="Week",
+            schTypeLimitsName="Fractional",
+            Name="Gains")
           # List of WeekSchedule objects (needed for Umi template creation)
           WeekSchedules = [sch_w_on, sch_w_off, sch_w_dhw, sch_w_gains]
 
@@ -401,78 +401,78 @@ examples will be shown for each object.
           # YearSchedules using DaySchedule objects
           # Always on
           dict_on = {
-          "Category": "Year",
-          "Parts": [
-            {
+            "Category": "Year",
+            "Parts": [
+                {
                 "FromDay": 1,
                 "FromMonth": 1,
                 "ToDay": 31,
                 "ToMonth": 12,
                 "Schedule": {"$ref": sch_w_on.id}
-            }],
-          "Type": "Fraction",
-          "Name": "AlwaysOn"}
+                }],
+            "Type": "Fraction",
+            "Name": "AlwaysOn"}
           sch_y_on = ar.YearSchedule.from_json(**dict_on)
           # Always off
           dict_off = {
-          "Category": "Year",
-          "Parts": [
-            {
+            "Category": "Year",
+            "Parts": [
+                {
                 "FromDay": 1,
                 "FromMonth": 1,
                 "ToDay": 31,
                 "ToMonth": 12,
                 "Schedule": {"$ref": sch_w_off.id}}],
-          "Type": "Fraction",
-          "Name": "AlwaysOff"}
+            "Type": "Fraction",
+            "Name": "AlwaysOff"}
           sch_y_off = ar.YearSchedule.from_json(**dict_off)
           # Year ON/OFF
           dict_on_off = {
-          "Category": "Year",
-          "Parts": [
-            {
+            "Category": "Year",
+            "Parts": [
+                {
                 "FromDay": 1,
                 "FromMonth": 1,
                 "ToDay": 31,
                 "ToMonth": 5,
                 "Schedule": {"$ref": sch_w_on.id}
-            },
-            {
+                },
+                {
                 "FromDay": 1,
                 "FromMonth": 6,
                 "ToDay": 31,
                 "ToMonth": 12,
                 "Schedule": {"$ref": sch_w_off.id}
-            }
+                }
                 ],
-          "Type": "Fraction",
-          "Name": "ON_OFF"}
+            "Type": "Fraction",
+            "Name": "ON_OFF"}
           sch_y_on_off = ar.YearSchedule.from_json(**dict_on_off)
           # DHW
           dict_dhw = {
-          "Category": "Year",
-          "Parts": [
-            {
+            "Category": "Year",
+            "Parts": [
+                {
                 "FromDay": 1,
                 "FromMonth": 1,
                 "ToDay": 31,
                 "ToMonth": 12,
                 "Schedule": {"$ref": sch_w_dhw.id}}],
-          "Type": "Fraction",
-          "Name": "DHW"}
+            "Type": "Fraction",
+            "Name": "DHW"}
           sch_y_dhw = ar.YearSchedule.from_json(**dict_dhw)
           # Internal gains
           dict_gains = {
-          "Category": "Year",
-          "Parts": [
-            {
+            "Category": "Year",
+            "Parts": [
+                {
                 "FromDay": 1,
                 "FromMonth": 1,
                 "ToDay": 31,
                 "ToMonth": 12,
                 "Schedule": {"$ref": sch_w_gains.id}}],
-          "Type": "Fraction",
-          "Name": "Gains"}
+            "Type": "Fraction",
+            "Name": "Gains"}
           sch_y_gains = ar.YearSchedule.from_json(**dict_gains)
           # List of YearSchedule objects (needed for Umi template creation)
           YearSchedules = [sch_y_on, sch_y_off, sch_y_on_off, sch_y_dhw, sch_y_gains]
@@ -511,10 +511,10 @@ examples will be shown for each object.
 
     # WindowSetting using WindowConstruction and YearSchedule objects
     window_setting = ar.WindowSetting(
-    Construction=window,
-    AfnWindowAvailability=sch_y_off,
-    ShadingSystemAvailabilitySchedule=sch_y_off,
-    ZoneMixingAvailabilitySchedule=sch_y_off)
+        Construction=window,
+        AfnWindowAvailability=sch_y_off,
+        ShadingSystemAvailabilitySchedule=sch_y_off,
+        ZoneMixingAvailabilitySchedule=sch_y_off)
     # List of WindowSetting objects (needed for Umi template creation)
     WindowSettings = [window_setting]
 
@@ -541,11 +541,11 @@ examples will be shown for each object.
 
     # DomesticHotWaterSetting using YearSchedule objects
     dhw_setting = ar.DomesticHotWaterSetting(
-    IsOn=True,
-    WaterSchedule=sch_y_dhw,
-    FlowRatePerFloorArea=0.03,
-    WaterSupplyTemperature=65,
-    WaterTemperatureInlet=10,)
+        IsOn=True,
+        WaterSchedule=sch_y_dhw,
+        FlowRatePerFloorArea=0.03,
+        WaterSupplyTemperature=65,
+        WaterTemperatureInlet=10,)
     # List of DomesticHotWaterSetting objects (needed for Umi template creation)
     DomesticHotWaterSettings = [dhw_setting]
 
@@ -580,13 +580,9 @@ examples will be shown for each object.
 
   .. code-block:: python
 
-    # DomesticHotWaterSetting using YearSchedule objects
-    dhw_setting = ar.DomesticHotWaterSetting(
-    IsOn=True,
-    WaterSchedule=sch_y_dhw,
-    FlowRatePerFloorArea=0.03,
-    WaterSupplyTemperature=65,
-    WaterTemperatureInlet=10,)
+    # VentilationSetting using YearSchedule objects
+    vent_setting = ar.VentilationSetting(
+        NatVentSchedule=sch_y_off, ScheduledVentilationSchedule=sch_y_off)
     # List of VentilationSetting objects (needed for Umi template creation)
     DomesticHotWaterSettings = [dhw_setting]
 .. _OpaqueMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.OpaqueMaterial.html

--- a/docs/creating_umi_template.rst
+++ b/docs/creating_umi_template.rst
@@ -505,10 +505,11 @@ examples will be shown for each object.
     ZoneMixingFlowRate=0.001,
     **kwargs)
 
-  Example of WindowSetting objects:
+  Example of WindowSetting object:
 
   .. code-block:: python
 
+    # WindowSetting using WindowConstruction and YearSchedule objects
     window_setting = ar.WindowSetting(
     Construction=window,
     AfnWindowAvailability=sch_y_off,
@@ -517,6 +518,36 @@ examples will be shown for each object.
     # List of WindowSetting objects (needed for Umi template creation)
     WindowSettings = [window_setting]
 
+4. Defining DHW settings
+
+  Creating Umi template objects to define DHW settings
+
+  Here are all the parameters and their default values for an
+  DomesticHotWaterSetting object (see DomesticHotWaterSetting_ doc for more information)
+
+  .. code-block:: python
+
+    def __init__(
+    IsOn=True,
+    WaterSchedule=None,
+    FlowRatePerFloorArea=0.03,
+    WaterSupplyTemperature=65,
+    WaterTemperatureInlet=10,
+    **kwargs)
+
+  Example of DomesticHotWaterSetting object:
+
+  .. code-block:: python
+
+    # DomesticHotWaterSetting using YearSchedule objects
+    dhw_setting = ar.DomesticHotWaterSetting(
+    IsOn=True,
+    WaterSchedule=sch_y_dhw,
+    FlowRatePerFloorArea=0.03,
+    WaterSupplyTemperature=65,
+    WaterTemperatureInlet=10,)
+    # List of DomesticHotWaterSetting objects (needed for Umi template creation)
+    DomesticHotWaterSettings = [dhw_setting]
 .. _OpaqueMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.OpaqueMaterial.html
 .. _GlazingMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GlazingMaterial.html
 .. _GasMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GasMaterial.html
@@ -528,3 +559,4 @@ examples will be shown for each object.
 .. _WeekSchedule: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.WeekSchedule.html
 .. _YearSchedule: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.YearSchedule.html
 .. _WindowSetting: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.WindowSetting.html
+.. _DomesticHotWaterSetting: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.DomesticHotWaterSetting.html

--- a/docs/creating_umi_template.rst
+++ b/docs/creating_umi_template.rst
@@ -677,6 +677,41 @@ required inputs for each object.
         Facade=wall_ext)
     # List of ZoneConstructionSet objects (needed for Umi template creation)
     ZoneConstructionSets = [zone_constr_set_perim, zone_constr_set_core]
+
+9. Defining zone loads
+
+  Creating Umi template objects to define zone loads
+
+  Here are all the parameters and their default values for an
+  ZoneLoad object (see ZoneLoad_ doc for more information)
+
+  .. code-block:: python
+
+    def __init__(
+        DimmingType="Continuous",
+        EquipmentAvailabilitySchedule=None,
+        EquipmentPowerDensity=12,
+        IlluminanceTarget=500,
+        LightingPowerDensity=12,
+        LightsAvailabilitySchedule=None,
+        OccupancySchedule=None,
+        IsEquipmentOn=True,
+        IsLightingOn=True,
+        IsPeopleOn=True,
+        PeopleDensity=0.2,
+        **kwargs)
+
+  Example of ZoneLoad object:
+
+  .. code-block:: python
+
+    # ZoneLoad using YearSchedule objects
+    zone_load = ar.ZoneLoad(
+        EquipmentAvailabilitySchedule=sch_y_gains,
+        LightsAvailabilitySchedule=sch_y_gains,
+        OccupancySchedule=sch_y_gains)
+    # List of ZoneLoad objects (needed for Umi template creation)
+    ZoneLoads = [zone_load]
 .. _OpaqueMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.OpaqueMaterial.html
 .. _GlazingMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GlazingMaterial.html
 .. _GasMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GasMaterial.html
@@ -692,3 +727,4 @@ required inputs for each object.
 .. _VentilationSetting: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.VentilationSetting.html
 .. _ZoneConditioning: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.ZoneConditioning.html
 .. _ZoneConstructionSet: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.ZoneConstructionSet.html
+.. _ZoneLoad: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.ZoneLoad.html

--- a/docs/creating_umi_template.rst
+++ b/docs/creating_umi_template.rst
@@ -10,8 +10,8 @@ examples will be shown for each object.
 
 1. Defining materials
 
-Creating Umi template objects to define materials (used as `Layers`
-in constructions).
+  Creating Umi template objects to define materials (used as `Layers`
+  in constructions).
 
     - Opaque materials
 
@@ -50,11 +50,84 @@ in constructions).
           # List of OpaqueMaterial objects (needed for Umi template creation)
           OpaqueMaterials = [concrete, insulation, brick, plywood]
 
-Blablablbalba
+    - Glazing materials
+
+      Here are all the parameters and their default values for a
+      GlazingMaterial object (see GlazingMaterial_ doc for more information)
+
+      .. code-block:: python
+
+        def __init__(
+        Density=2500,
+        Conductivity=0,
+        SolarTransmittance=0,
+        SolarReflectanceFront=0,
+        SolarReflectanceBack=0,
+        VisibleTransmittance=0,
+        VisibleReflectanceFront=0,
+        VisibleReflectanceBack=0,
+        IRTransmittance=0,
+        IREmissivityFront=0,
+        IREmissivityBack=0,
+        DirtFactor=1.0,
+        Type=None,
+        Cost=0.0,
+        Life=1,
+        **kwargs)
+
+      Example of GlazingMaterial object:
+
+        .. code-block:: python
+
+          glass = ar.GlazingMaterial(
+          Density=2500,
+          Conductivity=1,
+          SolarTransmittance=0.7,
+          SolarReflectanceFront=0.5,
+          SolarReflectanceBack=0.5,
+          VisibleTransmittance=0.7,
+          VisibleReflectanceFront=0.5,
+          VisibleReflectanceBack=0.5,
+          IRTransmittance=0.7,
+          IREmissivityFront=0.5,
+          IREmissivityBack=0.5,)
+          # List of GlazingMaterial objects (needed for Umi template creation)
+          GlazingMaterials = [glass]
+
+    - Gas materials
+
+      Here are all the parameters and their default values for a
+      GasMaterial object (see GasMaterial_ doc for more information)
+
+      .. code-block:: python
+
+        def __init__(
+        Cost=0,
+        EmbodiedCarbon=0,
+        EmbodiedEnergy=0,
+        SubstitutionTimestep=100,
+        TransportCarbon=0,
+        TransportDistance=0,
+        TransportEnergy=0,
+        SubstitutionRatePattern=None,
+        Conductivity=2.4,
+        Density=2400,
+        **kwargs)
+
+      Example of GasMaterial object:
+
+        .. code-block:: python
+
+          air = ar.GasMaterial(Conductivity=0.02, Density=1.24)
+          # List of GasMaterial objects (needed for Umi template creation)
+          GasMaterials = [air]
 
 
 .. _OpaqueMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.OpaqueMaterial.html
-
+.. _GlazingMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GlazingMaterial.html
+.. _GasMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GasMaterial.html
+.. _OpaqueConstruction: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.OpaqueConstruction.html
+.. _WindowConstruction: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.WindowConstruction.html
 
 
 

--- a/docs/creating_umi_template.rst
+++ b/docs/creating_umi_template.rst
@@ -21,23 +21,23 @@ examples will be shown for each object.
       .. code-block:: python
 
         def __init__(
-        Conductivity,
-        SpecificHeat,
-        SolarAbsorptance=0.7,
-        ThermalEmittance=0.9,
-        VisibleAbsorptance=0.7,
-        Roughness="Rough",
-        Cost=0,
-        Density=1,
-        MoistureDiffusionResistance=50,
-        EmbodiedCarbon=0.45,
-        EmbodiedEnergy=0,
-        TransportCarbon=0,
-        TransportDistance=0,
-        TransportEnergy=0,
-        SubstitutionRatePattern=None,
-        SubstitutionTimestep=20,
-        **kwargs)
+            Conductivity,
+            SpecificHeat,
+            SolarAbsorptance=0.7,
+            ThermalEmittance=0.9,
+            VisibleAbsorptance=0.7,
+            Roughness="Rough",
+            Cost=0,
+            Density=1,
+            MoistureDiffusionResistance=50,
+            EmbodiedCarbon=0.45,
+            EmbodiedEnergy=0,
+            TransportCarbon=0,
+            TransportDistance=0,
+            TransportEnergy=0,
+            SubstitutionRatePattern=None,
+            SubstitutionTimestep=20,
+            **kwargs)
 
       Example of OpaqueMaterial objects:
 
@@ -58,22 +58,22 @@ examples will be shown for each object.
       .. code-block:: python
 
         def __init__(
-        Density=2500,
-        Conductivity=0,
-        SolarTransmittance=0,
-        SolarReflectanceFront=0,
-        SolarReflectanceBack=0,
-        VisibleTransmittance=0,
-        VisibleReflectanceFront=0,
-        VisibleReflectanceBack=0,
-        IRTransmittance=0,
-        IREmissivityFront=0,
-        IREmissivityBack=0,
-        DirtFactor=1.0,
-        Type=None,
-        Cost=0.0,
-        Life=1,
-        **kwargs)
+            Density=2500,
+            Conductivity=0,
+            SolarTransmittance=0,
+            SolarReflectanceFront=0,
+            SolarReflectanceBack=0,
+            VisibleTransmittance=0,
+            VisibleReflectanceFront=0,
+            VisibleReflectanceBack=0,
+            IRTransmittance=0,
+            IREmissivityFront=0,
+            IREmissivityBack=0,
+            DirtFactor=1.0,
+            Type=None,
+            Cost=0.0,
+            Life=1,
+            **kwargs)
 
       Example of GlazingMaterial object:
 
@@ -102,17 +102,17 @@ examples will be shown for each object.
       .. code-block:: python
 
         def __init__(
-        Cost=0,
-        EmbodiedCarbon=0,
-        EmbodiedEnergy=0,
-        SubstitutionTimestep=100,
-        TransportCarbon=0,
-        TransportDistance=0,
-        TransportEnergy=0,
-        SubstitutionRatePattern=None,
-        Conductivity=2.4,
-        Density=2400,
-        **kwargs)
+            Cost=0,
+            EmbodiedCarbon=0,
+            EmbodiedEnergy=0,
+            SubstitutionTimestep=100,
+            TransportCarbon=0,
+            TransportDistance=0,
+            TransportEnergy=0,
+            SubstitutionRatePattern=None,
+            Conductivity=2.4,
+            Density=2400,
+            **kwargs)
 
       Example of GasMaterial object:
 
@@ -134,11 +134,11 @@ examples will be shown for each object.
       .. code-block:: python
 
         def __init__(
-        Layers,
-        Surface_Type=None,
-        Outside_Boundary_Condition=None,
-        IsAdiabatic=False,
-        **kwargs)
+            Layers,
+            Surface_Type=None,
+            Outside_Boundary_Condition=None,
+            IsAdiabatic=False,
+            **kwargs)
 
       Example of OpaqueConstruction objects:
 
@@ -176,14 +176,14 @@ examples will be shown for each object.
       .. code-block:: python
 
         def __init__(
-        Layers,
-        Category="Double",
-        AssemblyCarbon=0,
-        AssemblyCost=0,
-        AssemblyEnergy=0,
-        DisassemblyCarbon=0,
-        DisassemblyEnergy=0,
-        **kwargs)
+            Layers,
+            Category="Double",
+            AssemblyCarbon=0,
+            AssemblyCost=0,
+            AssemblyEnergy=0,
+            DisassemblyCarbon=0,
+            DisassemblyEnergy=0,
+            **kwargs)
 
       Example of WindowConstruction object:
 
@@ -202,14 +202,14 @@ examples will be shown for each object.
       .. code-block:: python
 
         def __init__(
-        *args,
-        AssemblyCarbon=0,
-        AssemblyCost=0,
-        AssemblyEnergy=0,
-        DisassemblyCarbon=0,
-        DisassemblyEnergy=0,
-        MassRatios=None,
-        **kwargs)
+            *args,
+            AssemblyCarbon=0,
+            AssemblyCost=0,
+            AssemblyEnergy=0,
+            DisassemblyCarbon=0,
+            DisassemblyEnergy=0,
+            MassRatios=None,
+            **kwargs)
 
       We observe that StructureDefinition uses MassRatio objects. Here are the
       parameters of MassRatio object (see MassRatio_ doc for more information)
@@ -240,15 +240,15 @@ examples will be shown for each object.
       .. code-block:: python
 
         def __init__(
-        Name=None,
-        idf=None,
-        start_day_of_the_week=0,
-        strict=False,
-        base_year=2018,
-        schType=None,
-        schTypeLimitsName=None,
-        values=None,
-        **kwargs)
+            Name=None,
+            idf=None,
+            start_day_of_the_week=0,
+            strict=False,
+            base_year=2018,
+            schType=None,
+            schTypeLimitsName=None,
+            values=None,
+            **kwargs)
 
       Example of DaySchedule objects:
 
@@ -280,15 +280,15 @@ examples will be shown for each object.
       .. code-block:: python
 
         def __init__(
-        Name=None,
-        idf=None,
-        start_day_of_the_week=0,
-        strict=False,
-        base_year=2018,
-        schType=None,
-        schTypeLimitsName=None,
-        values=None,
-        **kwargs)
+            Name=None,
+            idf=None,
+            start_day_of_the_week=0,
+            strict=False,
+            base_year=2018,
+            schType=None,
+            schTypeLimitsName=None,
+            values=None,
+            **kwargs)
 
       Example of WeekSchedule objects:
 
@@ -382,15 +382,15 @@ examples will be shown for each object.
       .. code-block:: python
 
         def __init__(
-        Name=None,
-        idf=None,
-        start_day_of_the_week=0,
-        strict=False,
-        base_year=2018,
-        schType=None,
-        schTypeLimitsName=None,
-        values=None,
-        **kwargs)
+            Name=None,
+            idf=None,
+            start_day_of_the_week=0,
+            strict=False,
+            base_year=2018,
+            schType=None,
+            schTypeLimitsName=None,
+            values=None,
+            **kwargs)
 
       YearSchedule are created from dictionaries.
       For example, we create YearSchedules from dictionaries and
@@ -487,23 +487,23 @@ examples will be shown for each object.
   .. code-block:: python
 
     def __init__(
-    Construction=None,
-    OperableArea=0.8,
-    AfnWindowAvailability=None,
-    AfnDischargeC=0.65,
-    AfnTempSetpoint=20,
-    IsVirtualPartition=False,
-    IsShadingSystemOn=False,
-    ShadingSystemAvailabilitySchedule=None,
-    ShadingSystemSetpoint=180,
-    ShadingSystemTransmittance=0.5,
-    ShadingSystemType=0,
-    Type=WindowType.External,
-    IsZoneMixingOn=False,
-    ZoneMixingAvailabilitySchedule=None,
-    ZoneMixingDeltaTemperature=2,
-    ZoneMixingFlowRate=0.001,
-    **kwargs)
+        Construction=None,
+        OperableArea=0.8,
+        AfnWindowAvailability=None,
+        AfnDischargeC=0.65,
+        AfnTempSetpoint=20,
+        IsVirtualPartition=False,
+        IsShadingSystemOn=False,
+        ShadingSystemAvailabilitySchedule=None,
+        ShadingSystemSetpoint=180,
+        ShadingSystemTransmittance=0.5,
+        ShadingSystemType=0,
+        Type=WindowType.External,
+        IsZoneMixingOn=False,
+        ZoneMixingAvailabilitySchedule=None,
+        ZoneMixingDeltaTemperature=2,
+        ZoneMixingFlowRate=0.001,
+        **kwargs)
 
   Example of WindowSetting object:
 
@@ -518,7 +518,7 @@ examples will be shown for each object.
     # List of WindowSetting objects (needed for Umi template creation)
     WindowSettings = [window_setting]
 
-4. Defining DHW settings
+5. Defining DHW settings
 
   Creating Umi template objects to define DHW settings
 
@@ -528,12 +528,12 @@ examples will be shown for each object.
   .. code-block:: python
 
     def __init__(
-    IsOn=True,
-    WaterSchedule=None,
-    FlowRatePerFloorArea=0.03,
-    WaterSupplyTemperature=65,
-    WaterTemperatureInlet=10,
-    **kwargs)
+        IsOn=True,
+        WaterSchedule=None,
+        FlowRatePerFloorArea=0.03,
+        WaterSupplyTemperature=65,
+        WaterTemperatureInlet=10,
+        **kwargs)
 
   Example of DomesticHotWaterSetting object:
 
@@ -548,6 +548,47 @@ examples will be shown for each object.
     WaterTemperatureInlet=10,)
     # List of DomesticHotWaterSetting objects (needed for Umi template creation)
     DomesticHotWaterSettings = [dhw_setting]
+
+6. Defining ventilation settings
+
+  Creating Umi template objects to define ventilation settings
+
+  Here are all the parameters and their default values for an
+  VentilationSetting object (see VentilationSetting_ doc for more information)
+
+  .. code-block:: python
+
+    def __init__(
+        NatVentSchedule=None,
+        ScheduledVentilationSchedule=None,
+        Afn=False,
+        Infiltration=0.1,
+        IsBuoyancyOn=True,
+        IsInfiltrationOn=True,
+        IsNatVentOn=False,
+        IsScheduledVentilationOn=False,
+        IsWindOn=False,
+        NatVentMaxOutdoorAirTemp=30,
+        NatVentMaxRelHumidity=90,
+        NatVentMinOutdoorAirTemp=0,
+        NatVentZoneTempSetpoint=18,
+        ScheduledVentilationAch=0.6,
+        ScheduledVentilationSetpoint=18,
+        **kwargs)
+
+  Example of VentilationSetting object:
+
+  .. code-block:: python
+
+    # DomesticHotWaterSetting using YearSchedule objects
+    dhw_setting = ar.DomesticHotWaterSetting(
+    IsOn=True,
+    WaterSchedule=sch_y_dhw,
+    FlowRatePerFloorArea=0.03,
+    WaterSupplyTemperature=65,
+    WaterTemperatureInlet=10,)
+    # List of VentilationSetting objects (needed for Umi template creation)
+    DomesticHotWaterSettings = [dhw_setting]
 .. _OpaqueMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.OpaqueMaterial.html
 .. _GlazingMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GlazingMaterial.html
 .. _GasMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GasMaterial.html
@@ -560,3 +601,4 @@ examples will be shown for each object.
 .. _YearSchedule: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.YearSchedule.html
 .. _WindowSetting: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.WindowSetting.html
 .. _DomesticHotWaterSetting: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.DomesticHotWaterSetting.html
+.. _VentilationSetting: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.VentilationSetting.html

--- a/docs/creating_umi_template.rst
+++ b/docs/creating_umi_template.rst
@@ -826,6 +826,7 @@ required inputs for each object.
   that can be imported into Umi as a template:
 
   .. code-block:: python
+
     umi_template.to_json()
 
 .. _OpaqueMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.OpaqueMaterial.html

--- a/docs/creating_umi_template.rst
+++ b/docs/creating_umi_template.rst
@@ -790,6 +790,44 @@ required inputs for each object.
         Core=core, Perimeter=perim, Structure=struct_definition, Windows=window_setting)
     # List of BuildingTemplate objects (needed for Umi template creation)
     BuildingTemplates = [building_template]
+
+12. Creating Umi template
+
+  Creating Umi template from all objects defined before
+  (see UmiTemplate_ doc for more information)
+
+  Example of BuildingTemplate object:
+
+  .. code-block:: python
+
+    # UmiTemplate using all lists of objects created before
+    umi_template = ar.UmiTemplate(
+        name="unnamed",
+        BuildingTemplates=BuildingTemplates,
+        GasMaterials=GasMaterials,
+        GlazingMaterials=GlazingMaterials,
+        OpaqueConstructions=OpaqueConstructions,
+        OpaqueMaterials=OpaqueMaterials,
+        WindowConstructions=WindowConstructions,
+        StructureDefinitions=StructureDefinitions,
+        DaySchedules=DaySchedules,
+        WeekSchedules=WeekSchedules,
+        YearSchedules=YearSchedules,
+        DomesticHotWaterSettings=DomesticHotWaterSettings,
+        VentilationSettings=VentilationSettings,
+        WindowSettings=WindowSettings,
+        ZoneConditionings=ZoneConditionings,
+        ZoneConstructionSets=ZoneConstructionSets,
+        ZoneLoads=ZoneLoads,
+        Zones=Zones,
+    )
+
+  And finally we use this following line of code to create the json file
+  that can be imported into Umi as a template:
+
+  .. code-block:: python
+    umi_template.to_json()
+
 .. _OpaqueMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.OpaqueMaterial.html
 .. _GlazingMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GlazingMaterial.html
 .. _GasMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GasMaterial.html
@@ -808,3 +846,4 @@ required inputs for each object.
 .. _ZoneLoad: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.ZoneLoad.html
 .. _Zone: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.Zone.html
 .. _BuildingTemplate: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.BuildingTemplate.html
+.. _UmiTemplate: https://archetypal.readthedocs.io/en/develop/reference/archetypal.umi_template.UmiTemplate.html

--- a/docs/creating_umi_template.rst
+++ b/docs/creating_umi_template.rst
@@ -185,7 +185,7 @@ examples will be shown for each object.
         DisassemblyEnergy=0,
         **kwargs)
 
-      Example of WindowConstruction objects:
+      Example of WindowConstruction object:
 
         .. code-block:: python
 
@@ -218,7 +218,7 @@ examples will be shown for each object.
 
         def __init__(HighLoadRatio=None, Material=None, NormalRatio=None)
 
-      Example of StructureDefinition objects:
+      Example of StructureDefinition object:
 
         .. code-block:: python
 

--- a/docs/creating_umi_template.rst
+++ b/docs/creating_umi_template.rst
@@ -712,6 +712,55 @@ required inputs for each object.
         OccupancySchedule=sch_y_gains)
     # List of ZoneLoad objects (needed for Umi template creation)
     ZoneLoads = [zone_load]
+
+10. Defining zones
+
+  Creating Umi template objects to define zones
+
+  Here are all the parameters and their default values for an
+  Zone object (see Zone_ doc for more information)
+
+  .. code-block:: python
+
+    def __init__(
+        Conditioning=None,
+        Constructions=None,
+        DomesticHotWater=None,
+        Loads=None,
+        Ventilation=None,
+        Windows=None,
+        InternalMassConstruction=None,
+        InternalMassExposedPerFloorArea=1.05,
+        DaylightMeshResolution=1,
+        DaylightWorkplaneHeight=0.8,
+        **kwargs)
+
+  Example of Zone objects:
+
+  .. code-block:: python
+
+    # Zones using ZoneConditioning, ZoneConstructionSet, DomesticWaterSetting,
+    # ZoneLoad, VentilationSetting, WindowSetting and OpaqueConstruction objects
+    # Perimeter zone
+    perim = ar.Zone(
+        Conditioning=zone_conditioning,
+        Constructions=zone_constr_set_perim,
+        DomesticHotWater=dhw_setting,
+        Loads=zone_load,
+        Ventilation=vent_setting,
+        Windows=window_setting,
+        InternalMassConstruction=wall_int)
+    # Core zone
+    core = ar.Zone(
+        Conditioning=zone_conditioning,
+        Constructions=zone_constr_set_core,
+        DomesticHotWater=dhw_setting,
+        Loads=zone_load,
+        Ventilation=vent_setting,
+        Windows=window_setting,
+        InternalMassConstruction=wall_int)
+    # List of Zone objects (needed for Umi template creation)
+    Zones = [perim, core]
 .. _OpaqueMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.OpaqueMaterial.html
 .. _GlazingMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GlazingMaterial.html
 .. _GasMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GasMaterial.html
@@ -728,3 +777,4 @@ required inputs for each object.
 .. _ZoneConditioning: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.ZoneConditioning.html
 .. _ZoneConstructionSet: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.ZoneConstructionSet.html
 .. _ZoneLoad: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.ZoneLoad.html
+.. _Zone: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.Zone.html

--- a/docs/creating_umi_template.rst
+++ b/docs/creating_umi_template.rst
@@ -6,7 +6,8 @@ modules available in `archetypal`
 The documentation will present how to create each Umi template object (e.g.
 `opaque materials`, `window settings`, `zone loads`, etc). Every inputs of
 each object will be presented with their default parameters, and simple
-examples will be shown for each object.
+examples will show how to create Umi template objects with at least the
+required inputs for each object.
 
 1. Defining materials
 
@@ -629,6 +630,53 @@ examples will be shown for each object.
         CoolingSchedule=sch_y_on, HeatingSchedule=sch_y_on, MechVentSchedule=sch_y_off)
     # List of ZoneConditioning objects (needed for Umi template creation)
     ZoneConditionings = [zone_conditioning]
+
+8. Defining zone construction sets
+
+  Creating Umi template objects to define zone construction sets
+
+  Here are all the parameters and their default values for an
+  ZoneConstructionSet object (see ZoneConstructionSet_ doc for more information)
+
+  .. code-block:: python
+
+    def __init__(
+        *args,
+        Zone_Names=None,
+        Slab=None,
+        IsSlabAdiabatic=False,
+        Roof=None,
+        IsRoofAdiabatic=False,
+        Partition=None,
+        IsPartitionAdiabatic=False,
+        Ground=None,
+        IsGroundAdiabatic=False,
+        Facade=None,
+        IsFacadeAdiabatic=False,
+        **kwargs)
+
+  Example of ZoneConstructionSet objects:
+
+  .. code-block:: python
+
+    # ZoneConstructionSet using OpaqueConstruction objects
+    # Perimeter zone
+    zone_constr_set_perim = ar.ZoneConstructionSet(
+        Slab=floor,
+        Roof=roof,
+        Partition=wall_int,
+        Ground=floor,
+        Facade=wall_ext)
+    # Core zone
+    zone_constr_set_core = ar.ZoneConstructionSet(
+        Slab=floor,
+        Roof=roof,
+        Partition=wall_int,
+        IsPartitionAdiabatic=True,
+        Ground=floor,
+        Facade=wall_ext)
+    # List of ZoneConstructionSet objects (needed for Umi template creation)
+    ZoneConstructionSets = [zone_constr_set_perim, zone_constr_set_core]
 .. _OpaqueMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.OpaqueMaterial.html
 .. _GlazingMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GlazingMaterial.html
 .. _GasMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GasMaterial.html
@@ -643,3 +691,4 @@ examples will be shown for each object.
 .. _DomesticHotWaterSetting: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.DomesticHotWaterSetting.html
 .. _VentilationSetting: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.VentilationSetting.html
 .. _ZoneConditioning: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.ZoneConditioning.html
+.. _ZoneConstructionSet: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.ZoneConstructionSet.html

--- a/docs/creating_umi_template.rst
+++ b/docs/creating_umi_template.rst
@@ -90,7 +90,7 @@ examples will be shown for each object.
           VisibleReflectanceBack=0.5,
           IRTransmittance=0.7,
           IREmissivityFront=0.5,
-          IREmissivityBack=0.5,)
+          IREmissivityBack=0.5)
           # List of GlazingMaterial objects (needed for Umi template creation)
           GlazingMaterials = [glass]
 
@@ -122,12 +122,117 @@ examples will be shown for each object.
           # List of GasMaterial objects (needed for Umi template creation)
           GasMaterials = [air]
 
+2. Defining constructions
+
+  Creating Umi template objects to define constructions (e.g. `OpaqueConstruction`).
+
+    - Opaque constructions
+
+      Here are all the parameters and their default values for an
+      OpaqueConstruction object (see OpaqueConstruction_ doc for more information)
+
+      .. code-block:: python
+
+        def __init__(
+        Layers,
+        Surface_Type=None,
+        Outside_Boundary_Condition=None,
+        IsAdiabatic=False,
+        **kwargs)
+
+      Example of OpaqueConstruction objects:
+
+        .. code-block:: python
+
+          # OpaqueConstruction using OpaqueMaterial objects
+          wall_int = ar.OpaqueConstruction(
+          Layers=[plywood],
+          Surface_Type="Partition",
+          Outside_Boundary_Condition="Zone",
+          IsAdiabatic=True)
+
+          wall_ext = ar.OpaqueConstruction(
+          Layers=[concrete, insulation, brick],
+          Surface_Type="Facade",
+          Outside_Boundary_Condition="Outdoors")
+
+          floor = ar.OpaqueConstruction(
+          Layers=[concrete, plywood],
+          Surface_Type="Ground",
+          Outside_Boundary_Condition="Zone")
+
+          roof = ar.OpaqueConstruction(
+          Layers=[plywood, insulation, brick],
+          Surface_Type="Roof",
+          Outside_Boundary_Condition="Outdoors")
+          # List of OpaqueConstruction objects (needed for Umi template creation)
+          OpaqueConstructions = [wall_int, wall_ext, floor, roof]
+
+    - Window constructions
+
+      Here are all the parameters and their default values for an
+      WindowConstruction object (see WindowConstruction_ doc for more information)
+
+      .. code-block:: python
+
+        def __init__(
+        Layers,
+        Category="Double",
+        AssemblyCarbon=0,
+        AssemblyCost=0,
+        AssemblyEnergy=0,
+        DisassemblyCarbon=0,
+        DisassemblyEnergy=0,
+        **kwargs)
+
+      Example of WindowConstruction objects:
+
+        .. code-block:: python
+
+          # WindowConstruction using GlazingMaterial and GasMaterial objects
+          window = ar.WindowConstruction(Layers=[glass, air, glass])
+          # List of WindowConstruction objects (needed for Umi template creation)
+          WindowConstructions = [window]
+
+    - Structure definition
+
+      Here are all the parameters and their default values for an
+      StructureDefinition object (see StructureDefinition_ doc for more information)
+
+      .. code-block:: python
+
+        def __init__(
+        *args,
+        AssemblyCarbon=0,
+        AssemblyCost=0,
+        AssemblyEnergy=0,
+        DisassemblyCarbon=0,
+        DisassemblyEnergy=0,
+        MassRatios=None,
+        **kwargs)
+
+      We observe that StructureDefinition uses MassRatio objects. Here are the
+      parameters of MassRatio object (see MassRatio_ doc for more information)
+
+      .. code-block:: python
+
+        def __init__(HighLoadRatio=None, Material=None, NormalRatio=None)
+
+      Example of StructureDefinition objects:
+
+        .. code-block:: python
+
+          # StructureDefinition using OpaqueMaterial objects
+          mass_ratio = ar.MassRatio(Material=plywood, NormalRatio="NormalRatio")
+          struct_definition = ar.StructureDefinition(MassRatios=[mass_ratio])
+          # List of StructureDefinition objects (needed for Umi template creation)
+          StructureDefinitions = [struct_definition]
 
 .. _OpaqueMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.OpaqueMaterial.html
 .. _GlazingMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GlazingMaterial.html
 .. _GasMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GasMaterial.html
 .. _OpaqueConstruction: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.OpaqueConstruction.html
 .. _WindowConstruction: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.WindowConstruction.html
-
-
+.. _StructureDefinition: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.StructureDefinition.html
+.. _MassRatio: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.MassRatio.html
 

--- a/docs/creating_umi_template.rst
+++ b/docs/creating_umi_template.rst
@@ -584,7 +584,51 @@ examples will be shown for each object.
     vent_setting = ar.VentilationSetting(
         NatVentSchedule=sch_y_off, ScheduledVentilationSchedule=sch_y_off)
     # List of VentilationSetting objects (needed for Umi template creation)
-    DomesticHotWaterSettings = [dhw_setting]
+    VentilationSettings = [vent_setting]
+
+7. Defining zone conditioning settings
+
+  Creating Umi template objects to define zone conditioning settings
+
+  Here are all the parameters and their default values for an
+  ZoneConditioning object (see ZoneConditioning_ doc for more information)
+
+  .. code-block:: python
+
+    def __init__(
+        CoolingCoeffOfPerf=1,
+        CoolingLimitType="NoLimit",
+        CoolingSetpoint=26,
+        CoolingSchedule=None,
+        EconomizerType="NoEconomizer",
+        HeatRecoveryEfficiencyLatent=0.65,
+        HeatRecoveryEfficiencySensible=0.7,
+        HeatRecoveryType="None",
+        HeatingCoeffOfPerf=1,
+        HeatingLimitType="NoLimit",
+        HeatingSetpoint=20,
+        HeatingSchedule=None,
+        IsCoolingOn=True,
+        IsHeatingOn=True,
+        IsMechVentOn=True,
+        MaxCoolFlow=100,
+        MaxCoolingCapacity=100,
+        MaxHeatFlow=100,
+        MaxHeatingCapacity=100,
+        MinFreshAirPerArea=0,
+        MinFreshAirPerPerson=0.00944,
+        MechVentSchedule=None,
+        **kwargs)
+
+  Example of ZoneConditioning object:
+
+  .. code-block:: python
+
+    # ZoneConditioning using YearSchedule objects
+    zone_conditioning = ar.ZoneConditioning(
+        CoolingSchedule=sch_y_on, HeatingSchedule=sch_y_on, MechVentSchedule=sch_y_off)
+    # List of ZoneConditioning objects (needed for Umi template creation)
+    ZoneConditionings = [zone_conditioning]
 .. _OpaqueMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.OpaqueMaterial.html
 .. _GlazingMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GlazingMaterial.html
 .. _GasMaterial: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.GasMaterial.html
@@ -598,3 +642,4 @@ examples will be shown for each object.
 .. _WindowSetting: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.WindowSetting.html
 .. _DomesticHotWaterSetting: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.DomesticHotWaterSetting.html
 .. _VentilationSetting: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.VentilationSetting.html
+.. _ZoneConditioning: https://archetypal.readthedocs.io/en/develop/reference/archetypal.template.ZoneConditioning.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,7 @@ independently.
    Reading and Running IDF files <reading_idf.rst>
    Parallel Processing <tutorials/parallel_process.rst>
    Managing Schedules <tutorials/schedules.rst>
+   Creating Umi template <creating_umi_template.rst>
    Reading and Editing UMI Template Files <tutorials/edit_umitemplate.rst>
    Troubleshooting <troubleshooting.rst>
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -200,6 +200,54 @@ class TestWeekSchedule:
         ]
         weekSched_to_json = weekSched_json[0].to_json()
 
+    def test_weekSchedule(self, config):
+        """
+        Args:
+            config:
+        """
+        import json
+        from archetypal import WeekSchedule, load_json_objects
+
+        clear_cache()
+        sch_d_on = ar.DaySchedule.from_values(
+            [1] * 24, Category="Day", schTypeLimitsName="Fractional", Name="AlwaysOn"
+        )
+        sch_d_off = ar.DaySchedule.from_values(
+            [0] * 24, Category="Day", schTypeLimitsName="Fractional", Name="AlwaysOff"
+        )
+
+        days = [
+            {"$ref": sch_d_on.id},
+            {"$ref": sch_d_off.id},
+            {"$ref": sch_d_on.id},
+            {"$ref": sch_d_off.id},
+            {"$ref": sch_d_on.id},
+            {"$ref": sch_d_off.id},
+            {"$ref": sch_d_on.id},
+        ]
+        a = ar.WeekSchedule(
+            days=days, Category="Week", schTypeLimitsName="Fractional", Name="OnOff_1"
+        )
+
+        dict_w_on = {
+            "Category": "Week",
+            "Days": [
+                {"$ref": sch_d_on.id},
+                {"$ref": sch_d_off.id},
+                {"$ref": sch_d_on.id},
+                {"$ref": sch_d_off.id},
+                {"$ref": sch_d_on.id},
+                {"$ref": sch_d_off.id},
+                {"$ref": sch_d_on.id},
+            ],
+            "Type": "Fraction",
+            "Name": "OnOff_2",
+        }
+        b = ar.WeekSchedule.from_json(**dict_w_on)
+
+        assert a.all_values == b.all_values
+        assert a.id != b.id
+
 
 class TestYearSchedule:
     """Series of tests for the :class:`YearSchedule` class"""
@@ -223,6 +271,53 @@ class TestYearSchedule:
             YearSchedule.from_json(**store) for store in datastore["YearSchedules"]
         ]
         yearSched_to_json = yearSched_json[0].to_json()
+
+    def test_yearSchedule(self, config):
+        """
+        Args:
+            config:
+        """
+        import json
+        from archetypal import YearSchedule, load_json_objects
+
+        clear_cache()
+        sch_d_on = ar.DaySchedule.from_values(
+            [1] * 24, Category="Day", schTypeLimitsName="Fractional", Name="AlwaysOn"
+        )
+        sch_d_off = ar.DaySchedule.from_values(
+            [0] * 24, Category="Day", schTypeLimitsName="Fractional", Name="AlwaysOff"
+        )
+
+        days = [
+            {"$ref": sch_d_on.id},
+            {"$ref": sch_d_off.id},
+            {"$ref": sch_d_on.id},
+            {"$ref": sch_d_off.id},
+            {"$ref": sch_d_on.id},
+            {"$ref": sch_d_off.id},
+            {"$ref": sch_d_on.id},
+        ]
+        sch_w_on_off = ar.WeekSchedule(
+            days=days, Category="Week", schTypeLimitsName="Fractional", Name="OnOff"
+        )
+
+        dict_year = {
+            "Category": "Year",
+            "Parts": [
+                {
+                    "FromDay": 1,
+                    "FromMonth": 1,
+                    "ToDay": 31,
+                    "ToMonth": 12,
+                    "Schedule": {"$ref": sch_w_on_off.id},
+                }
+            ],
+            "Type": "Fraction",
+            "Name": "OnOff",
+        }
+        a = ar.YearSchedule.from_json(**dict_year)
+
+        np.testing.assert_equal(a.all_values, np.resize(sch_w_on_off.all_values, 8760))
 
 
 class TestWindowType:

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -201,14 +201,13 @@ class TestWeekSchedule:
         weekSched_to_json = weekSched_json[0].to_json()
 
     def test_weekSchedule(self, config):
-        """
-        Args:
-            config:
-        """
+        """ Creates WeekSchedule from DaySchedule"""
         import json
         from archetypal import WeekSchedule, load_json_objects
 
         clear_cache()
+
+        # Creates 2 DaySchedules : 1 always ON and 1 always OFF
         sch_d_on = ar.DaySchedule.from_values(
             [1] * 24, Category="Day", schTypeLimitsName="Fractional", Name="AlwaysOn"
         )
@@ -216,6 +215,7 @@ class TestWeekSchedule:
             [0] * 24, Category="Day", schTypeLimitsName="Fractional", Name="AlwaysOff"
         )
 
+        # List of 7 dict with id of DaySchedule, representing the 7 days of the week
         days = [
             {"$ref": sch_d_on.id},
             {"$ref": sch_d_off.id},
@@ -225,10 +225,12 @@ class TestWeekSchedule:
             {"$ref": sch_d_off.id},
             {"$ref": sch_d_on.id},
         ]
+        # Creates WeekSchedule from list of DaySchedule
         a = ar.WeekSchedule(
             days=days, Category="Week", schTypeLimitsName="Fractional", Name="OnOff_1"
         )
 
+        # Dict of a WeekSchedule (like it would be written in json file)
         dict_w_on = {
             "Category": "Week",
             "Days": [
@@ -243,8 +245,11 @@ class TestWeekSchedule:
             "Type": "Fraction",
             "Name": "OnOff_2",
         }
+        # Creates WeekSchedule from dict (from json)
         b = ar.WeekSchedule.from_json(**dict_w_on)
 
+        # Makes sure WeekSchedules created with 2 methods have the same values
+        # And different ids
         assert a.all_values == b.all_values
         assert a.id != b.id
 
@@ -273,14 +278,14 @@ class TestYearSchedule:
         yearSched_to_json = yearSched_json[0].to_json()
 
     def test_yearSchedule(self, config):
-        """
-        Args:
-            config:
-        """
+        """ Creates YearSchedule from dict (json)"""
+
         import json
         from archetypal import YearSchedule, load_json_objects
 
         clear_cache()
+
+        # Creates 2 DaySchedules : 1 always ON and 1 always OFF
         sch_d_on = ar.DaySchedule.from_values(
             [1] * 24, Category="Day", schTypeLimitsName="Fractional", Name="AlwaysOn"
         )
@@ -288,6 +293,7 @@ class TestYearSchedule:
             [0] * 24, Category="Day", schTypeLimitsName="Fractional", Name="AlwaysOff"
         )
 
+        # List of 7 dict with id of DaySchedule, representing the 7 days of the week
         days = [
             {"$ref": sch_d_on.id},
             {"$ref": sch_d_off.id},
@@ -297,10 +303,12 @@ class TestYearSchedule:
             {"$ref": sch_d_off.id},
             {"$ref": sch_d_on.id},
         ]
+        # Creates WeekSchedule from list of DaySchedule
         sch_w_on_off = ar.WeekSchedule(
             days=days, Category="Week", schTypeLimitsName="Fractional", Name="OnOff"
         )
 
+        # Dict of a YearSchedule (like it would be written in json file)
         dict_year = {
             "Category": "Year",
             "Parts": [
@@ -315,8 +323,10 @@ class TestYearSchedule:
             "Type": "Fraction",
             "Name": "OnOff",
         }
+        # Creates YearSchedule from dict (from json)
         a = ar.YearSchedule.from_json(**dict_year)
 
+        # Makes sure YearSchedule has the same values as concatenate WeekSchedule
         np.testing.assert_equal(a.all_values, np.resize(sch_w_on_off.all_values, 8760))
 
 


### PR DESCRIPTION
Makes sure Umi schedule can be created from json (dictionary variable) file:

- Gets all_values for WeekSchedule from DaySchedule object

- Gets all_values for WeekSchedule from a list of dict of DaySchedule ids

- Gets all_values for YearSchedule  from a list of dict of DaySchedule ids

- Adds a function that create a simple temp IDF object.

- Makes sure idf object is not None and is an archetypal.IDF object when initializing UmiBase and Schedule classes (UmiBase and Schedule objects needs an idf object (not None) to write epbunch in it (e.g. to_year_week_day() function))