### PR TITLE
[Fix] WindowSettings now load correctly when reading from a file

### DIFF
--- a/archetypal/template/window.py
+++ b/archetypal/template/window.py
@@ -762,3 +762,28 @@ class WindowSetting(UmiBase, metaclass=Unique):
         ref = kwargs.get("ZoneMixingAvailabilitySchedule", None)
         w.ZoneMixingAvailabilitySchedule = w.get_ref(ref)
         return w
+
+    @classmethod
+    def from_ref(cls, ref, building_templates):
+        """In some cases, the WindowSetting is referenced in the DataStore to the
+        Windows property of a BuildingTemplate (instead of being listed in the
+        WindowSettings list. This is the case in the original
+        BostonTemplateLibrary.json.
+
+        Args:
+            ref (str): The referenced number
+            building_templates (list): List of BuildingTemplates from the datastore.
+
+        Returns:
+            WindowSetting: The parsed WindowSetting.
+        """
+        store = next(
+            iter(
+                filter(
+                    lambda x: x.get("$id") == ref,
+                    [bldg.get("Windows") for bldg in building_templates],
+                )
+            )
+        )
+        w = cls.from_json(**store)
+        return w

--- a/archetypal/template/window.py
+++ b/archetypal/template/window.py
@@ -684,7 +684,8 @@ class WindowSetting(UmiBase, metaclass=Unique):
             AfnDischargeC=self._float_mean(other, "AfnDischargeC", weights),
             AfnTempSetpoint=self._float_mean(other, "AfnTempSetpoint", weights),
             AfnWindowAvailability=self.AfnWindowAvailability.combine(
-                other.AfnWindowAvailability, weights),
+                other.AfnWindowAvailability, weights
+            ),
             IsShadingSystemOn=any([self.IsShadingSystemOn, other.IsShadingSystemOn]),
             IsVirtualPartition=any([self.IsVirtualPartition, other.IsVirtualPartition]),
             IsZoneMixingOn=any([self.IsZoneMixingOn, other.IsZoneMixingOn]),
@@ -703,10 +704,11 @@ class WindowSetting(UmiBase, metaclass=Unique):
             ),
             ZoneMixingFlowRate=self._float_mean(other, "ZoneMixingFlowRate", weights),
             ZoneMixingAvailabilitySchedule=self.ZoneMixingAvailabilitySchedule.combine(
-                other.ZoneMixingAvailabilitySchedule, weights),
-            ShadingSystemAvailabilitySchedule=self.ShadingSystemAvailabilitySchedule
-                .combine(
-                other.ShadingSystemAvailabilitySchedule, weights),
+                other.ZoneMixingAvailabilitySchedule, weights
+            ),
+            ShadingSystemAvailabilitySchedule=self.ShadingSystemAvailabilitySchedule.combine(
+                other.ShadingSystemAvailabilitySchedule, weights
+            ),
         )
         new_obj = self.__class__(**meta, **new_attr)
         new_obj._predecessors.extend(self._predecessors + other._predecessors)

--- a/archetypal/umi_template.py
+++ b/archetypal/umi_template.py
@@ -284,7 +284,9 @@ class UmiTemplate:
             ]
             t.Zones = [Zone.from_json(**store) for store in datastore["Zones"]]
             t.WindowSettings = [
-                WindowSetting.from_json(**store)
+                WindowSetting.from_ref(store["$ref"], datastore["BuildingTemplates"])
+                if "$ref" in store
+                else WindowSetting.from_json(**store)
                 for store in datastore["WindowSettings"]
             ]
             t.BuildingTemplates = [

--- a/archetypal/umi_template.py
+++ b/archetypal/umi_template.py
@@ -24,6 +24,7 @@ from archetypal import (
     ZoneConstructionSet,
     ZoneLoad,
     Zone,
+    WindowSetting,
     settings,
     UmiBase,
     MaterialLayer,
@@ -37,6 +38,7 @@ class UmiTemplate:
     """Main class supporting the definition of a multiple building templates and
     corresponding template objects.
     """
+
     def __init__(
         self,
         name="unnamed",
@@ -281,6 +283,10 @@ class UmiTemplate:
                 ZoneLoad.from_json(**store) for store in datastore["ZoneLoads"]
             ]
             t.Zones = [Zone.from_json(**store) for store in datastore["Zones"]]
+            t.WindowSettings = [
+                WindowSetting.from_json(**store)
+                for store in datastore["WindowSettings"]
+            ]
             t.BuildingTemplates = [
                 BuildingTemplate.from_json(**store)
                 for store in datastore["BuildingTemplates"]


### PR DESCRIPTION
Fixes an issue where reading an UMI Template Library would fail because WindowSettings would not have been loaded before the BuildingTemplate routine.