### PR TITLE
Modifies the OutputPrep logic to save at the end of the operation => faster

### DIFF
--- a/archetypal/schedule.py
+++ b/archetypal/schedule.py
@@ -105,13 +105,9 @@ class Schedule(object):
         """
         if idf:
             # Add the schedule to the existing idf
-            idf.add_object(
-                ep_object="Schedule:Constant".upper(),
-                **dict(
-                    Name=Name, Schedule_Type_Limits_Name="", Hourly_Value=hourly_value
-                ),
-                save=False
-            )
+            idf.add_object(ep_object="Schedule:Constant".upper(), **dict(
+                Name=Name, Schedule_Type_Limits_Name="", Hourly_Value=hourly_value
+            ))
             return cls(Name=Name, idf=idf, **kwargs)
         else:
             # Create a new idf object and add the schedule to it.
@@ -136,13 +132,9 @@ class Schedule(object):
             idf_scratch = easyopen(file.name)
             idf_scratch.__class__ = archetypal.IDF
 
-            idf_scratch.add_object(
-                ep_object="Schedule:Constant".upper(),
-                **dict(
-                    Name=Name, Schedule_Type_Limits_Name="", Hourly_Value=hourly_value
-                ),
-                save=False
-            )
+            idf_scratch.add_object(ep_object="Schedule:Constant".upper(), **dict(
+                Name=Name, Schedule_Type_Limits_Name="", Hourly_Value=hourly_value
+            ))
 
             sched = cls(Name=Name, idf=idf_scratch, **kwargs)
             return sched
@@ -917,15 +909,13 @@ class Schedule(object):
             archetypal.settings.unique_schedules.append(name)
 
             # Create idf_objects for schedule:day:hourly
-            ep_day = self.idf.add_object(
-                ep_object="Schedule:Day:Hourly".upper(),
-                save=False,
-                **dict(
-                    Name=name,
-                    Schedule_Type_Limits_Name=self.schTypeLimitsName,
-                    **{"Hour_{}".format(i + 1): unique_day[i] for i in range(24)}
-                )
-            )
+            ep_day = self.idf.add_object(ep_object="Schedule:Day:Hourly".upper(),
+                                         **dict(
+                                             Name=name,
+                                             Schedule_Type_Limits_Name=self.schTypeLimitsName,
+                                             **{"Hour_{}".format(i + 1): unique_day[i]
+                                                for i in range(24)}
+                                         ))
             ep_days.append(ep_day)
 
         # create unique weeks from unique days
@@ -970,24 +960,27 @@ class Schedule(object):
         # Create ep_weeks list and iterate over dict_week
         ep_weeks = []
         for week_id in dict_week:
-            ep_week = self.idf.add_object(
-                ep_object="Schedule:Week:Daily".upper(),
-                save=False,
-                **dict(
-                    Name=week_id,
-                    **{
-                        "{}_ScheduleDay_Name".format(
-                            calendar.day_name[day_num]
-                        ): dict_week[week_id]["day_{}".format(day_num)]
-                        for day_num in c.iterweekdays()
-                    },
-                    Holiday_ScheduleDay_Name=dict_week[week_id]["day_6"],
-                    SummerDesignDay_ScheduleDay_Name=dict_week[week_id]["day_1"],
-                    WinterDesignDay_ScheduleDay_Name=dict_week[week_id]["day_1"],
-                    CustomDay1_ScheduleDay_Name=dict_week[week_id]["day_2"],
-                    CustomDay2_ScheduleDay_Name=dict_week[week_id]["day_5"]
-                )
-            )
+            ep_week = self.idf.add_object(ep_object="Schedule:Week:Daily".upper(),
+                                          **dict(
+                                              Name=week_id,
+                                              **{
+                                                  "{}_ScheduleDay_Name".format(
+                                                      calendar.day_name[day_num]
+                                                  ): dict_week[week_id][
+                                                      "day_{}".format(day_num)]
+                                                  for day_num in c.iterweekdays()
+                                              },
+                                              Holiday_ScheduleDay_Name=
+                                              dict_week[week_id]["day_6"],
+                                              SummerDesignDay_ScheduleDay_Name=
+                                              dict_week[week_id]["day_1"],
+                                              WinterDesignDay_ScheduleDay_Name=
+                                              dict_week[week_id]["day_1"],
+                                              CustomDay1_ScheduleDay_Name=
+                                              dict_week[week_id]["day_2"],
+                                              CustomDay2_ScheduleDay_Name=
+                                              dict_week[week_id]["day_5"]
+                                          ))
             ep_weeks.append(ep_week)
 
         blocks = {}
@@ -1029,9 +1022,7 @@ class Schedule(object):
                 }
             )
 
-        ep_year = self.idf.add_object(
-            ep_object="Schedule:Year".upper(), save=False, **new_dict
-        )
+        ep_year = self.idf.add_object(ep_object="Schedule:Year".upper(), **new_dict)
         return ep_year, ep_weeks, ep_days
 
     def _date_field_interpretation(self, field):

--- a/archetypal/template/window.py
+++ b/archetypal/template/window.py
@@ -110,7 +110,7 @@ class WindowConstruction(UmiBase, metaclass=Unique):
 
         Example:
             >>> import archetypal as ar
-            >>> idf = ar.load_idf("myidf")
+            >>> idf = ar.IDF("myidf.idf")
             >>> construction_name = "Some construction name"
             >>> ar.WindowConstruction.from_epbunch(Name=construction_name,
             >>> idf=idf)
@@ -371,14 +371,12 @@ class WindowSetting(UmiBase, metaclass=Unique):
             UFactor=2.703,
             Solar_Heat_Gain_Coefficient=0.704,
             Visible_Transmittance=0.786,
-            save=False,
         )
 
         constr = idf.add_object(
             "CONSTRUCTION",
             Name="SINGLE PANE HW WINDOW",
             Outside_Layer="SimpleWindow:SINGLE PANE HW WINDOW",
-            save=False,
         )
         return cls.from_construction(Construction=constr)
 

--- a/archetypal/template/zone.py
+++ b/archetypal/template/zone.py
@@ -292,7 +292,6 @@ class Zone(UmiBase):
         )
         cons = self.idf.add_object(
             ep_object="Construction".upper(),
-            save=False,
             Name="InteriorFurnishings",
             Outside_Layer="Wood 6inch",
         )
@@ -300,7 +299,6 @@ class Zone(UmiBase):
         cons.Name = internal_mass + "_construction"
         new_epbunch = self.idf.add_object(
             ep_object="InternalMass".upper(),
-            save=False,
             Name=internal_mass,
             Construction_Name=cons.Name,
             Zone_or_ZoneList_Name=self.Name,

--- a/archetypal/trnsys.py
+++ b/archetypal/trnsys.py
@@ -135,7 +135,6 @@ def convert_idf_to_trnbuild(
             "kwargs": dict(
                 Variable_Name="Zone Thermostat Heating Setpoint Temperature",
                 Reporting_Frequency="hourly",
-                save=True,
             ),
         },
         {
@@ -143,7 +142,6 @@ def convert_idf_to_trnbuild(
             "kwargs": dict(
                 Variable_Name="Zone Thermostat Cooling Setpoint Temperature",
                 Reporting_Frequency="hourly",
-                save=True,
             ),
         },
     ]

--- a/tests/test_idfclass.py
+++ b/tests/test_idfclass.py
@@ -1,0 +1,15 @@
+import pytest
+
+from archetypal import IDF
+
+
+class TestIDF:
+    @pytest.fixture(scope="session")
+    def idf_model(self, config):
+        """An IDF model. Yields both the idf and the sql"""
+        file = "tests/input_data/umi_samples/B_Off_0.idf"
+        w = "tests/input_data/CAN_PQ_Montreal.Intl.AP.716270_CWEC.epw"
+        yield IDF(file, epw=w)
+
+    def test_processed_results(self, idf_model):
+        assert idf_model.processed_results

--- a/tests/test_trnsys.py
+++ b/tests/test_trnsys.py
@@ -732,7 +732,6 @@ class TestConvertEasy:
                 "kwargs": dict(
                     Variable_Name="Zone Thermostat Heating Setpoint Temperature",
                     Reporting_Frequency="hourly",
-                    save=True,
                 ),
             },
             {
@@ -740,7 +739,6 @@ class TestConvertEasy:
                 "kwargs": dict(
                     Variable_Name="Zone Thermostat Cooling Setpoint Temperature",
                     Reporting_Frequency="hourly",
-                    save=True,
                 ),
             },
         ]
@@ -1034,7 +1032,6 @@ class TestConvert:
                 "kwargs": dict(
                     Variable_Name="Zone Thermostat Heating Setpoint Temperature",
                     Reporting_Frequency="hourly",
-                    save=True,
                 ),
             },
             {
@@ -1042,7 +1039,6 @@ class TestConvert:
                 "kwargs": dict(
                     Variable_Name="Zone Thermostat Cooling Setpoint Temperature",
                     Reporting_Frequency="hourly",
-                    save=True,
                 ),
             },
         ]


### PR DESCRIPTION
must call OutputPrep.apply().save() 
.apply() applied the new output objects
.save() calls the IDF.save() method