### PR TITLE
Use of progress bar in parallel processes now supports nested processes

### DIFF
--- a/archetypal/cli.py
+++ b/archetypal/cli.py
@@ -95,7 +95,7 @@ pass_config = click.make_pass_decorator(CliConfig, ensure=True)
     "--verbose/--noverbose",
     "-v/-nv",
     "log_console",
-    default=True,
+    default=False,
     help="print log output to the console",
 )
 @click.option(
@@ -457,10 +457,14 @@ def transition(idf, to_version, cores, yes):
 
     file_paths = set_filepaths(idf)
     rundict = {
-        file: dict(idf_file=file, to_version=to_version, overwrite=overwrite)
-        for file in file_paths
+        file: dict(
+            idf_file=file, to_version=to_version, overwrite=overwrite, position=i + 1
+        )
+        for i, file in enumerate(file_paths)
     }
-    parallel_process(rundict, idf_version_updater, processors=cores)
+    parallel_process(
+        rundict, idf_version_updater, processors=cores, show_progress=True, position=0
+    )
     log(
         "Successfully transitioned files to version '{}' in {:,.2f} seconds".format(
             to_version, time.time() - start_time

--- a/archetypal/utils.py
+++ b/archetypal/utils.py
@@ -24,6 +24,7 @@ import sys
 import time
 import warnings
 from collections import OrderedDict
+from concurrent.futures._base import as_completed
 from datetime import datetime, timedelta
 from typing import Union
 
@@ -1086,7 +1087,8 @@ def rotate(l, n):
     return l[n:] + l[:n]
 
 
-def parallel_process(in_dict, function, processors=-1, use_kwargs=True):
+def parallel_process(in_dict, function, processors=-1, use_kwargs=True,
+                     show_progress=True, position=0):
     """A parallel version of the map function with a progress bar.
 
     Examples:
@@ -1100,9 +1102,10 @@ def parallel_process(in_dict, function, processors=-1, use_kwargs=True):
         >>>                      prep_outputs=True, expandobjects=True,
         >>>                      verbose='q')
         >>>           for file in files}
-        >>> result = parallel_process(rundict, IDF, use_kwargs=True)
+        >>> result = parallel_process(rundict,IDF,use_kwargs=True)
 
     Args:
+        position:
         in_dict (dict): A dictionary to iterate over. `function` is applied to value
             and key is used as an identifier.
         function (function): A python function to apply to the elements of
@@ -1119,14 +1122,16 @@ def parallel_process(in_dict, function, processors=-1, use_kwargs=True):
     if processors == -1:
         processors = min(len(in_dict), multiprocessing.cpu_count())
 
+    kwargs = {
+        "desc": function.__name__,
+        "total": len(in_dict),
+        "unit": "runs",
+        "unit_scale": True,
+        "leave": True,
+        "position": position,
+    }
+
     if processors == 1:
-        kwargs = {
-            "desc": function.__name__,
-            "total": len(in_dict),
-            "unit": "runs",
-            "unit_scale": True,
-            "leave": True,
-        }
         if use_kwargs:
             futures = {
                 a: submit(function, **in_dict[a]) for a in tqdm(in_dict, **kwargs)
@@ -1135,22 +1140,20 @@ def parallel_process(in_dict, function, processors=-1, use_kwargs=True):
             futures = {a: submit(function, in_dict[a]) for a in tqdm(in_dict, **kwargs)}
     else:
         with ProcessPoolExecutor(max_workers=processors) as pool:
-            with tqdm(
-                desc=function.__name__,
-                total=len(in_dict),
-                unit="runs",
-                unit_scale=True,
-                leave=True,
-            ) as progress:
                 futures = {}
 
                 if use_kwargs:
                     for a in in_dict:
                         future = pool.submit(function, **in_dict[a])
-                        future.add_done_callback(lambda p: progress.update())
                         futures[future] = a
                 else:
-                    futures = {pool.submit(function, in_dict[a]): a for a in in_dict}
+                    for a in in_dict:
+                        future = pool.submit(function, in_dict[a])
+                        futures[future] = a
+
+                # Print out the progress as tasks complete
+                for f in tqdm(as_completed(futures), **kwargs):
+                    pass
     out = {}
     # Get the results from the futures.
     for key in futures:

--- a/docs/examples/parallel_process.py
+++ b/docs/examples/parallel_process.py
@@ -29,7 +29,7 @@ def main():
         for k, file in idfs.file.to_dict().items()
     }
 
-    sql_files = parallel_process(rundict, run_eplus, use_kwargs=True, processors=-1)
+    sql_files = parallel_process(rundict, run_eplus, processors=-1, use_kwargs=True)
     return sql_files
 
 


### PR DESCRIPTION
For example, transitionining multiple idf files will now show the progress of each transition + the main loop.