### PR TITLE
Retrieve meters as  time-series from a dynamic list of available meters

### DIFF
--- a/archetypal/settings.py
+++ b/archetypal/settings.py
@@ -149,6 +149,7 @@ path_template_d18 = pkg_resources.resource_filename(resource_package, resource_p
 # Units
 
 unit_registry = pint.UnitRegistry()
+unit_registry.define("m3 = meter ** 3")
 
 
 class ZoneWeight(object):

--- a/docs/package_modules.rst
+++ b/docs/package_modules.rst
@@ -12,8 +12,8 @@ IDF Class
     :toctree: reference/
 
     IDF
-    run_eplus
     Outputs
+    Meter
 
 .. _templates_label:
 
@@ -40,7 +40,7 @@ Template Classes
     VentilationSetting
     WindowConstruction
     WindowSetting
-    Zone
+    ZoneDefinition
     ZoneConstructionSet
 
 Template Helper Classes
@@ -141,7 +141,8 @@ EnergySeries
     :nosignatures:
     :toctree: reference/
 
-    EnergySeries.from_sqlite
+    EnergySeries
+    EnergySeries.from_reportdata
     EnergySeries.unit_conversion
     EnergySeries.concurrent_sort
     EnergySeries.normalize

--- a/tests/test_energyseries.py
+++ b/tests/test_energyseries.py
@@ -1,14 +1,11 @@
 import os
 
-import archetypal as ar
 import pandas as pd
 import pytest
-
 from path import Path
 
+import archetypal as ar
 from archetypal import EnergySeries, get_eplus_dirs, settings, IDF
-
-import numpy as np
 
 
 @pytest.fixture(
@@ -37,7 +34,7 @@ def energy_series(config, request):
         table_name=("Heating:Electricity", "Heating:Gas", "Heating:DistrictHeating"),
     )
 
-    hl = EnergySeries.from_sqlite(
+    hl = EnergySeries.from_reportdata(
         report,
         name="Heating",
         normalize=False,
@@ -66,7 +63,7 @@ def test_EnergySeries(rd):
     import matplotlib.pyplot as plt
     from archetypal import EnergySeries
 
-    es = EnergySeries.from_sqlite(rd)
+    es = EnergySeries.from_reportdata(rd)
     es.plot()
     plt.show()
     print(es)

--- a/tests/test_idfclass.py
+++ b/tests/test_idfclass.py
@@ -14,18 +14,22 @@ from archetypal import (
 )
 
 
+@pytest.fixture()
+def shoebox_model(config):
+    """An IDF model. Yields both the idf"""
+    file = "tests/input_data/umi_samples/B_Off_0.idf"
+    w = "tests/input_data/CAN_PQ_Montreal.Intl.AP.716270_CWEC.epw"
+    yield IDF(file, epw=w)
+
+
 class TestIDF:
     @pytest.fixture(scope="session")
     def idf_model(self, config):
         """An IDF model. Yields both the idf"""
-        file = "tests/input_data/necb/NECB 2011-SmallOffice-NECB HDD Method-CAN_PQ_Montreal.Intl.AP.716270_CWEC.epw.idf"
-        w = "tests/input_data/CAN_PQ_Montreal.Intl.AP.716270_CWEC.epw"
-        yield IDF(file, epw=w)
-
-    @pytest.fixture()
-    def shoebox_model(self, config):
-        """An IDF model. Yields both the idf"""
-        file = "tests/input_data/umi_samples/B_Off_0.idf"
+        file = (
+            "tests/input_data/necb/NECB 2011-SmallOffice-NECB HDD "
+            "Method-CAN_PQ_Montreal.Intl.AP.716270_CWEC.epw.idf"
+        )
         w = "tests/input_data/CAN_PQ_Montreal.Intl.AP.716270_CWEC.epw"
         yield IDF(file, epw=w)
 
@@ -223,6 +227,18 @@ class TestIDF:
         np.testing.assert_almost_equal(
             actual=idf.area_conditioned, desired=area, decimal=0
         )
+
+
+class TestMeters:
+    def test_retrieve_meters_nosim(self, config, shoebox_model):
+        assert (
+            shoebox_model.meters
+            == "call IDF.simulate() to get a list of possible meters"
+        )
+
+    def test_retrieve_meters(self, config, shoebox_model):
+        shoebox_model.simulate()
+        shoebox_model.meters.OutputMeter.WaterSystems__MainsWater.values()
 
 
 class TestThreads:


### PR DESCRIPTION
This new feature adds a list of available meters to the IDF model. Once simulated at least once, the IDF.meters attribute is populated with meters categories ("Output:Meter" or "Output:Meter:Cumulative") and each category is populated with all the available meters.

For example, to retrieve the `WaterSystems:MainsWater` meter, simply call `idf.meters.OutputMeter.WaterSystems__MainsWater.values()`

With IPython, use `tab` and autocompletion to get a list of available meters.