### PR TITLE
Copying UmiBase objects returns objects with different hash

### DIFF
--- a/archetypal/template/glazing_material.py
+++ b/archetypal/template/glazing_material.py
@@ -190,7 +190,6 @@ class GlazingMaterial(MaterialBase):
                     self.IREmissivityFront == other.IREmissivityFront,
                     self.IREmissivityBack == other.IREmissivityBack,
                     self.DirtFactor == other.DirtFactor,
-                    self.Type == other.Type,
                     self.Cost == other.Cost,
                     self.Life == other.Life,
                 ]

--- a/archetypal/template/schedule.py
+++ b/archetypal/template/schedule.py
@@ -30,6 +30,11 @@ class UmiSchedule(Schedule, UmiBase):
         super(UmiSchedule, self).__init__(**kwargs)
         self.quantity = quantity
 
+    def __copy__(self):
+        copy = super(UmiSchedule, self).__copy__()
+        copy.epbunch = self.epbunch
+        return copy
+
     @classmethod
     def constant_schedule(
         cls, hourly_value=1, Name="AlwaysOn", Type="Fraction", idf=None, **kwargs

--- a/archetypal/template/umi_base.py
+++ b/archetypal/template/umi_base.py
@@ -128,6 +128,12 @@ class UmiBase(object):
 
         UmiBase.CREATED_OBJECTS.append(self)
 
+    def __copy__(self):
+        kwargs = self.mapping()
+        kwargs.pop("Name")
+        copy = self.__class__(Name=self.Name + "_copy", **kwargs)
+        return copy
+
     def __repr__(self):
         return ":".join([str(self.id), str(self.Name)])
 


### PR DESCRIPTION
A different Name (appended "_copy") is given to UmiBase objects.