### PR TITLE
Construct ZoneDefinition without all its parent objects

### DIFF
--- a/archetypal/template/glazing_material.py
+++ b/archetypal/template/glazing_material.py
@@ -190,7 +190,6 @@ class GlazingMaterial(MaterialBase):
                     self.IREmissivityFront == other.IREmissivityFront,
                     self.IREmissivityBack == other.IREmissivityBack,
                     self.DirtFactor == other.DirtFactor,
-                    self.Type == other.Type,
                     self.Cost == other.Cost,
                     self.Life == other.Life,
                 ]

--- a/archetypal/template/schedule.py
+++ b/archetypal/template/schedule.py
@@ -30,6 +30,11 @@ class UmiSchedule(Schedule, UmiBase):
         super(UmiSchedule, self).__init__(**kwargs)
         self.quantity = quantity
 
+    def __copy__(self):
+        copy = super(UmiSchedule, self).__copy__()
+        copy.epbunch = self.epbunch
+        return copy
+
     @classmethod
     def constant_schedule(
         cls, hourly_value=1, Name="AlwaysOn", Type="Fraction", idf=None, **kwargs

--- a/archetypal/template/umi_base.py
+++ b/archetypal/template/umi_base.py
@@ -128,6 +128,12 @@ class UmiBase(object):
 
         UmiBase.CREATED_OBJECTS.append(self)
 
+    def __copy__(self):
+        kwargs = self.mapping()
+        kwargs.pop("Name")
+        copy = self.__class__(Name=self.Name + "_copy", **kwargs)
+        return copy
+
     def __repr__(self):
         return ":".join([str(self.id), str(self.Name)])
 

--- a/archetypal/template/zonedefinition.py
+++ b/archetypal/template/zonedefinition.py
@@ -420,11 +420,13 @@ class ZoneDefinition(UmiBase):
         return zone
 
     @classmethod
-    def from_zone_epbunch(cls, zone_ep, **kwargs):
+    def from_zone_epbunch(cls, zone_ep, construct_parents=True, **kwargs):
         """Create a Zone object from an eppy 'ZONE' epbunch.
 
         Args:
             zone_ep (eppy.bunch_subclass.EpBunch): The Zone EpBunch.
+            construct_parents (bool): If False, skips construction of parents objects
+                such as Constructions, Conditioning, etc.
         """
         start_time = time.time()
         log('Constructing :class:`Zone` for zone "{}"'.format(zone_ep.Name))
@@ -439,13 +441,14 @@ class ZoneDefinition(UmiBase):
         zone._epbunch = zone_ep
         zone._zonesurfaces = zone_ep.zonesurfaces
 
-        zone.Constructions = ZoneConstructionSet.from_zone(zone, **kwargs)
-        zone.Conditioning = ZoneConditioning.from_zone(zone, **kwargs)
-        zone.Ventilation = VentilationSetting.from_zone(zone, **kwargs)
-        zone.DomesticHotWater = DomesticHotWaterSetting.from_zone(zone, **kwargs)
-        zone.Loads = ZoneLoad.from_zone(zone, **kwargs)
-        zone.InternalMassConstruction = InternalMass.from_zone(zone, **kwargs)
-        zone.Windows = WindowSetting.from_zone(zone, **kwargs)
+        if construct_parents:
+            zone.Constructions = ZoneConstructionSet.from_zone(zone, **kwargs)
+            zone.Conditioning = ZoneConditioning.from_zone(zone, **kwargs)
+            zone.Ventilation = VentilationSetting.from_zone(zone, **kwargs)
+            zone.DomesticHotWater = DomesticHotWaterSetting.from_zone(zone, **kwargs)
+            zone.Loads = ZoneLoad.from_zone(zone, **kwargs)
+            zone.InternalMassConstruction = InternalMass.from_zone(zone, **kwargs)
+            zone.Windows = WindowSetting.from_zone(zone, **kwargs)
 
         log(
             'completed Zone "{}" constructor in {:,.2f} seconds'.format(


### PR DESCRIPTION
use `construct_parents=False`