### PR TITLE
Fixed an issue where EnergyPlusProcessError would raise an error

### DIFF
--- a/archetypal/eplus_interface/exceptions.py
+++ b/archetypal/eplus_interface/exceptions.py
@@ -22,7 +22,7 @@ class EnergyPlusProcessError(Exception):
         try:
             name = self.idf.idfname.abspath()
         except Exception:
-            name = self.idf
+            name = self.idf.name
         msg = ":\n".join([name, self.stderr])
         return msg
 


### PR DESCRIPTION
When getting the name of an idf file for an in memory idf