### PR TITLE
A prompt has been added when getting IDF.meters and IDF.variables for a weather file run when design_day is specified in the IDF file.

### DIFF
--- a/archetypal/idfclass/meters.py
+++ b/archetypal/idfclass/meters.py
@@ -95,7 +95,6 @@ class Meter:
                 f"Try another environment_type (1, 2 or 3) or specify IDF.annual=True "
                 f"and rerun the simulation."
             )
-            return EnergySeries()
         return EnergySeries.from_reportdata(
             report,
             to_units=units,

--- a/archetypal/idfclass/meters.py
+++ b/archetypal/idfclass/meters.py
@@ -77,7 +77,7 @@ class Meter:
         if environment_type is None:
             try:
                 for ctrl in self._idf.idfobjects["SIMULATIONCONTROL"]:
-                    if ctrl.obj[-1].lower() == "yes":
+                    if ctrl.obj[-1].lower() == "yes" and self._idf.design_day is False:
                         environment_type = 3
                     else:
                         environment_type = 1 if self._idf.design_day else 3

--- a/archetypal/idfclass/meters.py
+++ b/archetypal/idfclass/meters.py
@@ -81,7 +81,7 @@ class Meter:
                         environment_type = 3
                     else:
                         environment_type = 1 if self._idf.design_day else 3
-            except (KeyError, IndexError):
+            except (KeyError, IndexError, AttributeError):
                 reporting_frequency = 3
         report = ReportData.from_sqlite(
             sqlite_file=self._idf.sql_file,

--- a/archetypal/idfclass/variables.py
+++ b/archetypal/idfclass/variables.py
@@ -72,7 +72,7 @@ class Variable:
                         environment_type = 3
                     else:
                         environment_type = 1 if self._idf.design_day else 3
-            except (KeyError, IndexError):
+            except (KeyError, IndexError, AttributeError):
                 reporting_frequency = 3
         report = ReportData.from_sqlite(
             sqlite_file=self._idf.sql_file,

--- a/archetypal/idfclass/variables.py
+++ b/archetypal/idfclass/variables.py
@@ -86,7 +86,6 @@ class Variable:
                 f"Try another environment_type (1, 2 or 3) or specify IDF.annual=True "
                 f"and rerun the simulation."
             )
-            return EnergySeries()
         return EnergyDataFrame.from_reportdata(
             report,
             name=self._epobject.Variable_Name,

--- a/archetypal/idfclass/variables.py
+++ b/archetypal/idfclass/variables.py
@@ -66,14 +66,21 @@ class Variable:
             self._idf.addidfobject(self._epobject)
             self._idf.simulate()
         if environment_type is None:
-            try:
-                for ctrl in self._idf.idfobjects["SIMULATIONCONTROL"]:
-                    if ctrl.obj[-1].lower() == "yes" and self._idf.design_day is False:
-                        environment_type = 3
-                    else:
-                        environment_type = 1 if self._idf.design_day else 3
-            except (KeyError, IndexError, AttributeError):
-                reporting_frequency = 3
+            if self._idf.design_day:
+                environment_type = 1
+            elif self._idf.annual:
+                environment_type = 3
+            else:
+                # the environment_type is specified by the simulationcontrol.
+                try:
+                    for ctrl in self._idf.idfobjects["SIMULATIONCONTROL"]:
+                        if ctrl.Run_Simulation_for_Weather_File_Run_Periods.lower() \
+                                == "yes":
+                            environment_type = 3
+                        else:
+                            environment_type = 1
+                except (KeyError, IndexError, AttributeError):
+                    reporting_frequency = 3
         report = ReportData.from_sqlite(
             sqlite_file=self._idf.sql_file,
             table_name=self._epobject.Variable_Name,

--- a/archetypal/idfclass/variables.py
+++ b/archetypal/idfclass/variables.py
@@ -68,7 +68,7 @@ class Variable:
         if environment_type is None:
             try:
                 for ctrl in self._idf.idfobjects["SIMULATIONCONTROL"]:
-                    if ctrl.obj[-1].lower() == "yes":
+                    if ctrl.obj[-1].lower() == "yes" and self._idf.design_day is False:
                         environment_type = 3
                     else:
                         environment_type = 1 if self._idf.design_day else 3

--- a/archetypal/idfclass/variables.py
+++ b/archetypal/idfclass/variables.py
@@ -1,7 +1,8 @@
 """EnergyPlus variables module."""
+import logging
 
 import pandas as pd
-from energy_pandas import EnergyDataFrame
+from energy_pandas import EnergyDataFrame, EnergySeries
 from geomeppy.patches import EpBunch
 
 from archetypal.idfclass.extensions import bunch2db
@@ -34,6 +35,7 @@ class Variable:
         self,
         units=None,
         reporting_frequency="Hourly",
+        environment_type=None,
         normalize=False,
         sort_values=False,
     ):
@@ -51,6 +53,8 @@ class Variable:
                 is detected automatically and a dimensionality check is performed.
             reporting_frequency (str): Timestep, Hourly, Daily, Monthly,
                 RunPeriod, Environment, Annual or Detailed. Default "Hourly".
+            environment_type (int): The environment type (1 = Design Day, 2 = Design
+                Run Period, 3 = Weather Run Period).
             normalize (bool): Normalize between 0 and 1.
             sort_values (bool): If True, values are sorted (default ascending=True).
 
@@ -61,12 +65,28 @@ class Variable:
         if self._epobject not in self._idf.idfobjects[self._epobject.key]:
             self._idf.addidfobject(self._epobject)
             self._idf.simulate()
+        if environment_type is None:
+            try:
+                for ctrl in self._idf.idfobjects["SIMULATIONCONTROL"]:
+                    if ctrl.obj[-1].lower() == "yes":
+                        environment_type = 3
+                    else:
+                        environment_type = 1 if self._idf.design_day else 3
+            except (KeyError, IndexError):
+                reporting_frequency = 3
         report = ReportData.from_sqlite(
             sqlite_file=self._idf.sql_file,
             table_name=self._epobject.Variable_Name,
-            environment_type=1 if self._idf.design_day else 3,
+            environment_type=environment_type,
             reporting_frequency=bunch2db[reporting_frequency],
         )
+        if report.empty:
+            logging.error(
+                f"The variable is empty for environment_type `{environment_type}`. "
+                f"Try another environment_type (1, 2 or 3) or specify IDF.annual=True "
+                f"and rerun the simulation."
+            )
+            return EnergySeries()
         return EnergyDataFrame.from_reportdata(
             report,
             name=self._epobject.Variable_Name,


### PR DESCRIPTION
It is also now possible to specify the `environment_type` directly in the .values() method:

```python
>>> from archetypal import IDF
>>> idf = IDF.from_example_files("RefBldgMediumOfficeNew2004_Chicago.idf",
>>>    epw=r"C:\EnergyPlusV9-2-0\WeatherData\USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw",
>>> )
>>> idf.simulate()
>>> idf.meters.OutputMeters.Heating__DistrictHeating.values(environment_type=3)  # 3 is Full weather run, 1 is Design Day.
ERROR:root:The variable is empty for environment_type `3`. Try another environment_type (1, 2 or 3) or specify IDF.annual=True and rerun the simulation.
EnergySeries([], dtype: float64), units:
```

```python
>>> idf.meters.OutputMeter.Heating__Electricity.values(environment_type=1)

2018-01-21 00:00:00    6.803790e+08
2018-01-21 01:00:00    5.337955e+08
2018-01-21 02:00:00    6.851795e+08
2018-01-21 03:00:00    5.372879e+08
2018-01-21 04:00:00    6.889698e+08
2018-01-21 05:00:00    5.400416e+08
2018-01-21 06:00:00    7.251851e+08
2018-01-21 07:00:00    6.575614e+08
2018-01-21 08:00:00    6.457270e+08
2018-01-21 09:00:00    6.334369e+08
2018-01-21 10:00:00    6.301503e+08
2018-01-21 11:00:00    6.209483e+08
2018-01-21 12:00:00    6.199935e+08
2018-01-21 13:00:00    6.229337e+08
2018-01-21 14:00:00    6.245591e+08
2018-01-21 15:00:00    6.257906e+08
2018-01-21 16:00:00    6.235730e+08
2018-01-21 17:00:00    6.213948e+08
2018-01-21 18:00:00    5.933533e+08
2018-01-21 19:00:00    5.101329e+08
2018-01-21 20:00:00    6.642959e+08
2018-01-21 21:00:00    5.230211e+08
2018-01-21 22:00:00    6.740986e+08
2018-01-21 23:00:00    5.293273e+08
2018-07-21 00:00:00    0.000000e+00
2018-07-21 01:00:00    0.000000e+00
2018-07-21 02:00:00    0.000000e+00
2018-07-21 03:00:00    0.000000e+00
2018-07-21 04:00:00    0.000000e+00
2018-07-21 05:00:00    0.000000e+00
2018-07-21 06:00:00    0.000000e+00
2018-07-21 07:00:00    0.000000e+00
2018-07-21 08:00:00    0.000000e+00
2018-07-21 09:00:00    0.000000e+00
2018-07-21 10:00:00    0.000000e+00
2018-07-21 11:00:00    0.000000e+00
2018-07-21 12:00:00    0.000000e+00
2018-07-21 13:00:00    0.000000e+00
2018-07-21 14:00:00    0.000000e+00
2018-07-21 15:00:00    0.000000e+00
2018-07-21 16:00:00    0.000000e+00
2018-07-21 17:00:00    0.000000e+00
2018-07-21 18:00:00    0.000000e+00
2018-07-21 19:00:00    0.000000e+00
2018-07-21 20:00:00    0.000000e+00
2018-07-21 21:00:00    0.000000e+00
2018-07-21 22:00:00    0.000000e+00
2018-07-21 23:00:00    0.000000e+00
Name: Heating:Electricity, dtype: float64, units:J
```