### PR TITLE
A typo in DifferentialEnthalpy EconomizerTypes has been fixed

### DIFF
--- a/archetypal/template/conditioning.py
+++ b/archetypal/template/conditioning.py
@@ -61,7 +61,8 @@ class EconomizerTypes(UmiBaseEnum):
 
     NoEconomizer = 0
     DifferentialDryBulb = 1
-    DifferentialEnthalphy = 2
+    DifferentialEnthalpy = 2
+    DifferentialEnthalphy = 2  # fix for the UMI bug
 
 
 class IdealSystemLimit(UmiBaseEnum):


### PR DESCRIPTION
Fixes #204

Robust because it can take the old typo in