### PR TITLE
`eplus_interface` classes can now look in `/bin` when E+ version is lower or equal to 7.2

### DIFF
--- a/archetypal/eplus_interface/basement.py
+++ b/archetypal/eplus_interface/basement.py
@@ -57,14 +57,10 @@ class BasementThread(Thread):
 
         # Get executable using shutil.which (determines the extension based on
         # the platform, eg: .exe. And copy the executable to tmp
-        self.basement_exe = Path(
-            shutil.which(
-                "Basement", path=self.eplus_home / "PreProcess" / "GrndTempCalc"
-            )
-        ).copy(self.run_dir)
-        self.basement_idd = (
-            self.eplus_home / "PreProcess" / "GrndTempCalc" / "BasementGHT.idd"
-        ).copy(self.run_dir)
+        self.basement_exe = Path(shutil.which("Basement", path=self.eplus_home)).copy(
+            self.run_dir
+        )
+        self.basement_idd = (self.eplus_home / "BasementGHT.idd").copy(self.run_dir)
         self.outfile = self.idf.name
 
         # The BasementGHTin.idf file is copied from the self.include list (
@@ -207,11 +203,13 @@ class BasementThread(Thread):
 
     @property
     def eplus_home(self):
-        eplus_exe, eplus_home = paths_from_version(self.idf.as_version.dash)
-        if not Path(eplus_home).exists():
-            raise EnergyPlusVersionError(
-                msg=f"No EnergyPlus Executable found for version "
-                f"{EnergyPlusVersion(self.idf.as_version)}"
-            )
+        """Get the version-dependant directory where executables are installed."""
+        if self.idf.file_version <= EnergyPlusVersion("7.2"):
+            install_dir = self.idf.file_version.current_install_dir / "bin"
         else:
-            return Path(eplus_home)
+            install_dir = (
+                self.idf.file_version.current_install_dir
+                / "PreProcess"
+                / "GrndTempCalc"
+            )
+        return install_dir

--- a/archetypal/eplus_interface/expand_objects.py
+++ b/archetypal/eplus_interface/expand_objects.py
@@ -59,9 +59,8 @@ class ExpandObjectsThread(Thread):
             self.epw = self.idf.epw.copy(tmp / "in.epw").expand()
             self.idfname = Path(self.idf.savecopy(tmp / "in.idf")).expand()
             self.idd = self.idf.iddname.copy(tmp / "Energy+.idd").expand()
-            self.expandobjectsexe = Path(
-                shutil.which("ExpandObjects", path=self.eplus_home.expand())
-            ).copy2(tmp)
+            expand_object_exe = shutil.which("ExpandObjects", path=self.eplus_home)
+            self.expandobjectsexe = Path(expand_object_exe).copy2(tmp)
             self.run_dir = Path(tmp).expand()
 
             # Run ExpandObjects Program
@@ -151,11 +150,9 @@ class ExpandObjectsThread(Thread):
 
     @property
     def eplus_home(self):
-        eplus_exe, eplus_home = paths_from_version(self.idf.as_version.dash)
-        if not Path(eplus_home).exists():
-            raise EnergyPlusVersionError(
-                msg=f"No EnergyPlus Executable found for version "
-                f"{EnergyPlusVersion(self.idf.as_version)}"
-            )
+        """Get the version-dependant directory where executables are installed."""
+        if self.idf.file_version <= EnergyPlusVersion("7.2"):
+            install_dir = self.idf.file_version.current_install_dir / "bin"
         else:
-            return Path(eplus_home)
+            install_dir = self.idf.file_version.current_install_dir
+        return install_dir

--- a/archetypal/eplus_interface/slab.py
+++ b/archetypal/eplus_interface/slab.py
@@ -58,12 +58,10 @@ class SlabThread(Thread):
 
         # Get executable using shutil.which (determines the extension based on
         # the platform, eg: .exe. And copy the executable to tmp
-        self.slabexe = Path(
-            shutil.which("Slab", path=self.eplus_home / "PreProcess" / "GrndTempCalc")
-        ).copy(self.run_dir)
-        self.slabidd = (
-            self.eplus_home / "PreProcess" / "GrndTempCalc" / "SlabGHT.idd"
-        ).copy(self.run_dir)
+        self.slabexe = Path(shutil.which("Slab", path=self.eplus_home)).copy(
+            self.run_dir
+        )
+        self.slabidd = (self.eplus_home / "SlabGHT.idd").copy(self.run_dir)
 
         # The GHTin.idf file is copied from the self.include list (added by
         # ExpandObjects. If self.include is empty, no need to run Slab.
@@ -164,11 +162,13 @@ class SlabThread(Thread):
 
     @property
     def eplus_home(self):
-        eplus_exe, eplus_home = paths_from_version(self.idf.as_version.dash)
-        if not Path(eplus_home).exists():
-            raise EnergyPlusVersionError(
-                msg=f"No EnergyPlus Executable found for version "
-                f"{EnergyPlusVersion(self.idf.as_version)}"
-            )
+        """Get the version-dependant directory where executables are installed."""
+        if self.idf.file_version <= EnergyPlusVersion("7.2"):
+            install_dir = self.idf.file_version.current_install_dir / "bin"
         else:
-            return Path(eplus_home)
+            install_dir = (
+                self.idf.file_version.current_install_dir
+                / "PreProcess"
+                / "GrndTempCalc"
+            )
+        return install_dir

--- a/archetypal/eplus_interface/transition.py
+++ b/archetypal/eplus_interface/transition.py
@@ -171,6 +171,9 @@ class TransitionThread(Thread):
 
         generator = TransitionExe(self.idf, tmp_dir=tmp)
 
+        # set the initial version from which we are transitioning
+        last_successful_transition = self.idf.file_version
+
         for trans in tqdm(
             generator,
             total=len(generator.transitions),
@@ -214,10 +217,14 @@ class TransitionThread(Thread):
                             time.time() - start_time
                         )
                     )
+                    last_successful_transition = trans.trans
                     self.success_callback()
                     for line in self.p.stderr:
                         self.msg_callback(line.decode("utf-8"))
                 else:
+                    # set the version of the IDF the latest it was able to transition
+                    # to.
+                    self.idf.as_version = last_successful_transition
                     self.msg_callback("Transition failed")
                     self.failure_callback()
 

--- a/archetypal/eplus_interface/version.py
+++ b/archetypal/eplus_interface/version.py
@@ -9,9 +9,7 @@ from packaging.version import Version
 from path import Path
 
 from archetypal import settings
-from archetypal.eplus_interface.exceptions import (
-    InvalidEnergyPlusVersion,
-)
+from archetypal.eplus_interface.exceptions import InvalidEnergyPlusVersion
 
 
 class EnergyPlusVersion(Version):


### PR DESCRIPTION
Executables for Basement and Slab preprocessors are installed in the bin folder of the installation folder of E+