### PR TITLE
The default behavior of the IDF constructor has been changed to parse as the file version.

### DIFF
--- a/archetypal/idfclass/idf.py
+++ b/archetypal/idfclass/idf.py
@@ -181,7 +181,7 @@ class IDF(GeomIDF):
         self,
         idfname: Optional[Union[str, IO, Path]] = None,
         epw=None,
-        as_version: Union[str, EnergyPlusVersion] = settings.ep_version,
+        as_version: Union[str, EnergyPlusVersion] = None,
         annual=False,
         design_day=False,
         expandobjects=False,
@@ -236,7 +236,7 @@ class IDF(GeomIDF):
         self.idfname = idfname
         self.epw = epw
         self.file_version = kwargs.get("file_version", None)
-        self.as_version = as_version if as_version else settings.ep_version
+        self.as_version = as_version if as_version else self.file_version
         self._custom_processes = custom_processes
         self._include = include
         self.keep_data_err = keep_data_err

--- a/archetypal/idfclass/idf.py
+++ b/archetypal/idfclass/idf.py
@@ -700,7 +700,7 @@ class IDF(GeomIDF):
     @property
     def as_version(self):
         """Specify the desired :class:`EnergyPlusVersion` for the IDF model."""
-        return self._as_version
+        return EnergyPlusVersion(self._as_version)
 
     @as_version.setter
     def as_version(self, value):


### PR DESCRIPTION
Previously, the default version for this package (settings.ep_version) was used to parse an IDF file, upgrading the file to this version if needed. Now, the model will be parsed using the file version; if a simulation is required and the energyplus installation for that version is not available, an appropriate error will be thrown inviting to specify `as_version` either in the `IDF` constructor or in the `IDF.simulate` method.