### PR TITLE
Supports Material:NoMass and Material:AirGap in OpaqueMaterial class

### DIFF
--- a/archetypal/eplus_interface/version.py
+++ b/archetypal/eplus_interface/version.py
@@ -121,7 +121,7 @@ class EnergyPlusVersion(Version):
         """List the idd file version found on this machine."""
         if not self.valid_idd_paths:
             # Little hack in case E+ is not installed
-            _choices = set(settings.ep_version)
+            _choices = {settings.ep_version,}
         else:
             _choices = set(self.valid_idd_paths.keys())
 

--- a/archetypal/settings.py
+++ b/archetypal/settings.py
@@ -155,4 +155,4 @@ class ZoneWeight(object):
 zone_weight = ZoneWeight(n=0)
 
 # Latest version of EnergyPlus compatible with archetypal looks for ENERGYPLUS_VERSION in os.environ
-ep_version = os.getenv("ENERGYPLUS_VERSION", "9-2-0").replace("-", ".")
+ep_version = os.getenv("ENERGYPLUS_VERSION", "9-2-0")

--- a/archetypal/template/constructions/opaque_construction.py
+++ b/archetypal/template/constructions/opaque_construction.py
@@ -418,7 +418,7 @@ class OpaqueConstruction(LayeredConstruction):
             **kwargs: keywords passed to the LayeredConstruction constructor.
         """
         assert epbunch.key.lower() in ("internalmass", "construction", 'construction:internalsource'), (
-            f"Expected ('Internalmass', 'Construction', 'construction:internalsouce')." f"Got '{epbunch.key}'."
+            f"Expected ('Internalmass', 'Construction', 'construction:internalsource')." f"Got '{epbunch.key}'."
         )
         name = epbunch.Name
 

--- a/archetypal/template/materials/nomass_material.py
+++ b/archetypal/template/materials/nomass_material.py
@@ -361,6 +361,7 @@ class NoMassMaterial(MaterialBase):
         """
         return idf.newidfobject(
             "MATERIAL:NOMASS",
+            Name=self.Name,
             Roughness=self.Roughness,
             Thermal_Resistance=self.r_value,
             Thermal_Absorptance=self.ThermalEmittance,

--- a/tests/test_idfclass.py
+++ b/tests/test_idfclass.py
@@ -250,7 +250,7 @@ class TestIDF:
 
     def test_init_version(self, idf):
         """Test creation of in-memory IDF file"""
-        assert idf.file_version.dot == settings.ep_version
+        assert idf.file_version.dash == settings.ep_version
 
         # test another instance in this session with a different version number.
         idf = IDF(as_version="8-9-0")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -46,4 +46,4 @@ class TestEnergyPlusVersion:
         idd_version = EnergyPlusVersion("9.2")
         idd_version._valid_paths = {}  # fakes not finding any versions on machine.
 
-        assert idd_version.valid_versions == {"9-2-0"}
+        assert idd_version.valid_versions == {"9-2-0",}


### PR DESCRIPTION
Only OpaqueMaterial.from_epbunch and OpaqueMaterial.to_epbunch will support conversion from and to Material:NoMass or Material:AirGap. The UmiTemplateEditor still cannot support those components.