### PR TITLE
Added ability to combine two UmiTemplateLibrary objects to form a larger one

### DIFF
--- a/archetypal/umi_template.py
+++ b/archetypal/umi_template.py
@@ -147,16 +147,19 @@ class UmiTemplateLibrary:
 
     def __add__(self, other: "UmiTemplateLibrary"):
         """Combined """
-        for bld in other.BuildingTemplates:
-            for p, k, c in traverse(bld):
-                c.id = None
+        for key, group in other:
+            # for each group
+            for component in group:
+                component.id = None  # Reset the component's id
+                # traverse each object using generator
+                for parent, key, obj in traverse(component):
+                    obj.id = None  # Reset children ID
 
         attrs = {}
         for group, value in self:
             attrs[group] = value + other.__dict__[group]
 
         return self.__class__(**attrs, name=self.name)
-
 
     def _clear_components_list(self, except_groups=None):
         """Clear components lists except except_groups."""

--- a/archetypal/umi_template.py
+++ b/archetypal/umi_template.py
@@ -4,6 +4,7 @@ import json
 import logging as lg
 from collections import OrderedDict
 from concurrent.futures.thread import ThreadPoolExecutor
+from copy import copy, deepcopy
 
 from pandas.io.common import get_handle
 from path import Path
@@ -143,6 +144,19 @@ class UmiTemplateLibrary:
         """Iterate over component groups. Yields tuple of (group, value)."""
         for group in self._LIB_GROUPS:
             yield group, self.__dict__[group]
+
+    def __add__(self, other: "UmiTemplateLibrary"):
+        """Combined """
+        for bld in other.BuildingTemplates:
+            for p, k, c in traverse(bld):
+                c.id = None
+
+        attrs = {}
+        for group, value in self:
+            attrs[group] = value + other.__dict__[group]
+
+        return self.__class__(**attrs, name=self.name)
+
 
     def _clear_components_list(self, except_groups=None):
         """Clear components lists except except_groups."""

--- a/tests/test_umi.py
+++ b/tests/test_umi.py
@@ -35,6 +35,19 @@ from archetypal.umi_template import UmiTemplateLibrary, no_duplicates
 class TestUmiTemplate:
     """Test suite for the UmiTemplateLibrary class"""
 
+    def test_add(self):
+        """Test combining two template library objects together."""
+        file = "tests/input_data/umi_samples/BostonTemplateLibrary_nodup.json"
+
+        a = UmiTemplateLibrary.open(file)
+        b = UmiTemplateLibrary.open(file)
+
+        c = a + b
+        assert c.name == a.name  # name of c hould be name of a (convention, first wins)
+        assert len(c.BuildingTemplates) == len(a.BuildingTemplates) + len(
+            b.BuildingTemplates
+        )  # Nb of templates should be double in this case.
+
     def test_template_to_template(self):
         """load the json into UmiTemplateLibrary object, then convert back to json and
         compare"""
@@ -122,7 +135,7 @@ class TestUmiTemplate:
 
     @pytest.fixture()
     def manual_umitemplate_library(self, config):
-        """ Creates Umi template from scratch """
+        """Creates Umi template from scratch"""
 
         # region Defines materials
 


### PR DESCRIPTION
@szvsw, here's my implementation of the `__add__` method. The trick was in the traverse method that actually takes in an UmiBase object, and not an UmiTemplateLibrary object like I originally thought. 