### PR TITLE
Feature/measures

### DIFF
--- a/archetypal/template/building_template.py
+++ b/archetypal/template/building_template.py
@@ -31,6 +31,7 @@ class BuildingTemplate(UmiBase):
 
     .. image:: ../images/template/buildingtemplate.png
     """
+
     _CREATED_OBJECTS = []
 
     __slots__ = (

--- a/archetypal/template/conditioning.py
+++ b/archetypal/template/conditioning.py
@@ -88,6 +88,7 @@ class ZoneConditioning(UmiBase):
 
     .. image:: ../images/template/zoninfo-conditioning.png
     """
+
     _CREATED_OBJECTS = []
 
     __slots__ = (

--- a/archetypal/template/dhw.py
+++ b/archetypal/template/dhw.py
@@ -19,6 +19,7 @@ class DomesticHotWaterSetting(UmiBase):
 
     .. image:: ../images/template/zoneinfo-dhw.png
     """
+
     _CREATED_OBJECTS = []
 
     __slots__ = (

--- a/archetypal/template/load.py
+++ b/archetypal/template/load.py
@@ -42,6 +42,7 @@ class ZoneLoad(UmiBase):
 
     .. image:: ../images/template/zoneinfo-loads.png
     """
+
     _CREATED_OBJECTS = []
 
     __slots__ = (

--- a/archetypal/template/materials/gas_material.py
+++ b/archetypal/template/materials/gas_material.py
@@ -14,6 +14,7 @@ class GasMaterial(MaterialBase):
 
     .. image:: ../images/template/materials-gas.png
     """
+
     _CREATED_OBJECTS = []
 
     __slots__ = ("_type", "_conductivity", "_density")

--- a/archetypal/template/materials/glazing_material.py
+++ b/archetypal/template/materials/glazing_material.py
@@ -17,6 +17,7 @@ class GlazingMaterial(MaterialBase):
     .. image:: ../images/template/materials-glazing.png
 
     """
+
     _CREATED_OBJECTS = []
 
     __slots__ = (

--- a/archetypal/template/measures/README.md
+++ b/archetypal/template/measures/README.md
@@ -178,8 +178,17 @@ measure.mutate(lib)
 ```
 If you omit a `MeasureProperty` from the subclass definition, the default value from the original measure will be used.
 
-*nb:* To combine instanced measures, you should iterate over the properties of one measure and add them as properties to another measure (or add them as properties to both).
+You can also easily combine measure instances using addition, e.g.:
 
+```
+measure_c = measure_a + measure_b
+```
+
+or
+
+```
+measure_a += measure_b
+```
 # Subclassing Measure
 
 You may easily define Measure your own `Measure` subclasses to preserve or share your custom measures.  Inherit `Measure`, call provide a `_name` and `_description` class arg, and then define your measure in `__init__`.  `__init__` should accept `**kwargs` and should provide default values for the properties it uses by their `AttrNames`. the See the following example:

--- a/archetypal/template/measures/README.md
+++ b/archetypal/template/measures/README.md
@@ -1,0 +1,8 @@
+# UMI Measures module
+
+Measures.
+
+## I
+
+
+

--- a/archetypal/template/measures/README.md
+++ b/archetypal/template/measures/README.md
@@ -43,6 +43,20 @@ This behavior is enabled by default, but if you wish to preserve the entanglemen
 measure.mutate(lib, disentangle=False)
 ```
 
+### Changelogs
+
+The changes executed by a measure are returneed as a changelog by each call to mutate an `UmiTemplateLibrary` or `BuildingTemplate`.  The log is formatted as a dict, with `BuildingTemplate`s as keys, and tuples of `(address, original_value, new_value)` as values:
+
+```
+changelog = measure.mutate(lib)
+```
+
+You can also generate a changelog of pending changes without mutating the target by using the `changelog` method.  
+
+```
+changelog = measure.changelog(lib)
+```
+
 # What is a Measure
 
 An UMI `Measure`  is defined by a collection of `MeasureProperties`, which each define a set of `MeasureActions` to mutate a `BuildingTemplate`.  `Measures` can be composed into new `Measures` which combine several other` Measures`, and each` MeasureProperty` or `MeasureAction` may have `Validators` associated with it (e.g. to only allow upgrades to be applied if certain conditions are met).  Each `MeasureProperty` or `MeasureAction` may also have a `Transformer` associated with it, which allows the new values applied by an upgrade to depend on the current state of the `BuildingTemplate` (see [Advanced Usage](#advanced-usage)).  Archetypal comes with several pre-defined measures, but the `Measure` class makes it easy to define your own.

--- a/archetypal/template/measures/README.md
+++ b/archetypal/template/measures/README.md
@@ -31,6 +31,7 @@ measure.HeatingCoP = 3.2
 measure.mutate(lib.BuildingTemplates[0]) 
 ```
 
+
 ### Entanglement
 
 By default, when you apply a measure, it will duplicate and replace the tree of any objects which are mutated so that the mutation does not ripple out to other parents of the targeted object.  
@@ -42,6 +43,8 @@ This behavior is enabled by default, but if you wish to preserve the entanglemen
 ```
 measure.mutate(lib, disentangle=False)
 ```
+
+*nb: when mutating a template (rather than a whole library) with `disentangle=True`, the new components will not automatically be added to any of the template's parent libraries `LIB_GROUPS` arrays automatically; remember to call `lib.update_components_list()` to extract the new components into their corresponding `LIB_GROUPS` array, e.g. `lib.ZoneDefinitions`.*
 
 ### Changelogs
 

--- a/archetypal/template/measures/README.md
+++ b/archetypal/template/measures/README.md
@@ -1,8 +1,267 @@
-# UMI Measures module
+# UMI Measures Module
 
-Measures.
+UMI `Measures` provide a convenient way to apply technology packages to Archetypal `BuildingTemplates`.  For instance, to upgrade the HVAC system efficiency, it's as easy as the following:
 
-## I
+```
+from archetypal import UmiTemplateLibrary
+from archetypal.template.measures.measure import SetCOP
+
+lib = UmiTemplateLibrary.open("/path/to/your/lib.json")
+
+measure = SetCOP(HeatingCoP=4, CoolingCoP=3.25)
+
+measure.mutate(lib)
+
+```
+
+### Changing Property Values
+
+You may change the values of each MeasureProperty at any time.  You may use either bracket notation and the desired `MeasureProperty`'s `Name` to change the value, or dot notation and the `MeasureProperty`'s `AttrName`.
+```
+# Change a MeasureProperty's value using bracket notation and the Property's Name
+measure["Heating CoP"] = 3.0 
+
+# Apply measure to the entire library
+measure.mutate(lib)
+
+# Change a measure Property's value using dot notation and the Property's AttrName
+measure.HeatingCoP = 3.2 
+
+# Only apply the measure to a single template
+measure.mutate(lib.BuildingTemplates[0]) 
+```
+
+### Entanglement
+
+By default, when you apply a measure, it will duplicate and replace the tree of any objects which are mutated so that the mutation does not ripple out to other parents of the targeted object.  
+
+For instance, consider a measure which only upgrades the Perimeter Loads Equipment Power Density but not the Core. If a single ZoneDefinition is used for the Core and Perimeter, or separate definitions are used but they both use the same ZoneLoad object, the Perimeter ZoneDefinition and ZoneLoads objects will be duplicated and replaced to prevent propoagating the Perimeter changes to the core.  
+
+This behavior is enabled by default, but if you wish to preserve the entanglement and allow the knock-on effects to propagate, simply set `disentangle=False` when mutating the library:
+
+```
+measure.mutate(lib, disentangle=False)
+```
+
+# What is a Measure
+
+An UMI `Measure`  is defined by a collection of `MeasureProperties`, which each define a set of `MeasureActions` to mutate a `BuildingTemplate`.  `Measures` can be composed into new `Measures` which combine several other` Measures`, and each` MeasureProperty` or `MeasureAction` may have `Validators` associated with it (e.g. to only allow upgrades to be applied if certain conditions are met).  Each `MeasureProperty` or `MeasureAction` may also have a `Transformer` associated with it, which allows the new values applied by an upgrade to depend on the current state of the `BuildingTemplate` (see [Advanced Usage](#advanced-usage)).  Archetypal comes with several pre-defined measures, but the `Measure` class makes it easy to define your own.
+
+# Defining a Measure
+To define a measure, create a Measure object, at least one MeasureProperty, and at least one MeasureAction associated with that property.  Each MeasureProperty represets a control variable, and the value of the Property will be passed to each of the MeasureActions associated with it when the measure's upgrade is used to mutate the library.  Once you've defined your Actions and Properties, you will associate them and connect them to the Measure: 
+
+```
+from archetypal.template.measures.measure import Measure, MeasureProperty, MeasureAction
+
+measure = Measure(
+	Name="Set Heating Setpoint",
+    Description="Change HVAC heating setpoints to reduce heating loads",
+)
+
+heating_property = MeasureProperty(
+    Name="Heating Setpoint",
+    AttrName="HeatingSetpoint",
+    Description="Change the heating setpoint",
+    Default=17,
+)
+
+heating_core_action = MeasureAction(
+    Name="Change Core Heating Setpoint",
+    Lookup=["Core", "Conditioning", "HeatingSetpoint"],
+)
+
+heating_perimeter_action = MeasureAction(
+    Name="Change Perimeter Heating Setpoint",
+    Lookup=["Perimeter", "Conditioning", "HeatingSetpoint"],
+)
+
+# Add actions to the heating_property
+heating_property.add_action(heating_perimeter_action)
+heating_property.add_action(heating_core_action)
+
+# Add the heating_property to the measure
+measure.add_property(heating_property)
+
+# Apply the measure to the whole library
+measure.mutate(your_library) 
+
+```
+
+Although the measure above only uses one property, you may use arbitrarily many properties in a Measure, potentially allowing you to define large-scale macros for upgrading a template library.
+
+You may also create your properties and actions in the reverse order, and pass them in during object creation.  The following is equivalent to the snippet above:
+
+```
+from archetypal.template.measures.measure import Measure, MeasureProperty, MeasureAction
+
+heating_core_action = MeasureAction(
+    Name="Change Core Heating Setpoint",
+    Lookup=["Core", "Conditioning", "HeatingSetpoint"],
+)
+
+heating_perimeter_action = MeasureAction(
+    Name="Change Perimeter Heating Setpoint",
+    Lookup=["Perimeter", "Conditioning", "HeatingSetpoint"],
+)
+
+heating_property = MeasureProperty(
+    Name="Heating Setpoint",
+    AttrName="HeatingSetpoint",
+    Description="Change the heating setpoint",
+    Default=17,
+    Actions=[heating_core_action, heating_perimeter_action]
+)
+
+measure = Measure(
+	Name="Set Heating Setpoint",
+    Description="Change HVAC heating setpoints to reduce heating loads",
+    Properties=[heating_property]
+)
+```
+
+## Action Creator Syntactic Sugar
+If a MeasureProperty only uses one Action, you may define it inline with the MeasureProperty as a shortcut, and the action will be internally created and associated with the property automatically:
+
+```
+infiltration_ach_property = MeasureProperty(
+    Name="Infiltration",
+    AttrName="Infiltration",
+    Description="Change Infiltration ACH",
+    Default=0.2,
+    Lookup=["Perimeter", "Ventilation", "Infiltration"],
+)
+
+measure = Measure(
+    Name="Upgrade Tightness",
+    Description="Change the infiltration airchange frequency of the perimeter zone.",
+    Properties=infiltration_ach_property # You may pass in a list or a single property
+)
+```
+
+## Extending a Measure
+
+You may also add `MeasureProperties` to `Measures` at any time after their initial creation, or similarly `MeasureActions` to` MeasureProperties`, so they are easily extensible.
+
+```
+cop_and_infiltration_measure = SetCOP()
+cop_and_ventilation_measure.add_property(
+    Name="Infiltration",
+    AttrName="Infiltration",
+    Description="Change perimeter infiltration ach",
+    Default=0.2,
+    Lookup=["Perimeter", "Ventilation", "Infiltration"]
+)
+```
+
+# Measure Presets
+
+Some of Archetypal's predfined Measure subclasses may come with presets defined as classmethods, for instance `SetInfiltration`:
+
+```
+measure = SetInfiltration.Best()
+measure.mutate(your_library)
+```
+
+See the documentation for the predfined Measure subclasses for a list of available presets.
+
+# Combining Measures
+
+Existing Measure subclasses can be easily combined using class inheritance:
+```
+class SetCOPandInfiltration(SetCOP, SetInfiltration):
+    HeatingCoP = 3.75
+    CoolingCoP = 3.5
+    Infiltration = 0.2
+
+measure = SetCoPAndInfiltration()
+measure.mutate(lib)
+```
+If you omit a `MeasureProperty` from the subclass definition, the default value from the original measure will be used.
+
+*nb:* To combine instanced measures, you should iterate over the properties of one measure and add them as properties to another measure (or add them as properties to both).
+
+# Subclassing Measure
+
+You may easily define Measure your own `Measure` subclasses to preserve or share your custom measures.  Inherit `Measure`, call provide a `_name` and `_description` class arg, and then define your measure in `__init__`.  `__init__` should accept `**kwargs` and should provide default values for the properties it uses by their `AttrNames`. the See the following example:
+
+```
+class SetHVACSetpoint(Measure):
+    _name = "Set HVAC Setpoints"
+    _description = "Set heating and cooling setpoints for all zones
+
+    def __init__(self, HeatingSetpoint=18, CoolingSetpoing=24, **kwargs):
+        super().__init__(**kwargs)
+
+        heating_property = MeasureProperty(
+            Name="Heating Setpoint",
+            AttrName="HeatingSetpoint",
+            Description="Change the heating setpoint in deg. c.",
+            Default=HeatingSetpoint,
+            Lookup=["Perimeter", "Conditioning", "HeatingSetpoint"]
+        )
+        heating_property.add_action(
+            Name="Change core heating setpoint in deg. c."
+            Lookup=["Core", "Conditioning", "HeatingSetpoint]
+        )
+        self.add_property(heating_property)
+
+        cooling_property = MeasureProperty(
+            Name="Cooling Setpoint",
+            AttrName="CoolingSetpoint",
+            Description="Change the cooling setpoint in deg. c.",
+            Default=CoolingSetpoint,
+            Lookup=["Perimeter", "Conditioning", "CoolingSetpoint"]
+        )
+        cooling_property.add_action(
+            Name="Change core cooling setpoint in deg. c."
+            Lookup=["Core", "Conditioning", "CoolingSetpoint]
+        )
+        self.add_property(cooling_property)
+```
+## Defining Measure Subclass Presets
+
+Given an existing `Measure` subclass, you may define a preset (i.e. a collections of values for each Property) with two different techniques.
+
+### Option 1: Classmethods
+
+Add one `classmethod` for each preset which returns an instance of the `Measure` subclass with `MeasureProperty` values set as desired, e.g.:
+
+```
+class SetHVACSetpoints(Measure):
+
+    ...
+
+    @classmethod
+    def Extreme(cls):
+        return cls(
+            HeatingSetpoint=15,
+            CoolingSetpoint=27
+        )
+```
+
+Then, instantiate a preset by calling the `classmethod`:
+
+```
+measure = SetHVACSetpoints.Extreme()
+```
+
+### Option 2: Inheritance Presets
+
+Create a subclass for each preset which inherits the desired measure, and set the `MeasureProperty` values using class attrs.  No need for an `__init__` method!  See here:
+
+```
+class ExtremeSetpoints(SetHVACSetpoints):
+    HeatingSetpoint = 15
+    CoolingSetpoint = 15
+
+measure = ExtremeSetpoints()
+```
+
+This technique is especially convenient when combining multiple measures into a single measure (see [Combining Measures](#combining-measures) )
+
+# Advanced Usage
+
+TODO: Document `Validators`, `Transformers`, and dynamic `Lookup`.
 
 
 

--- a/archetypal/template/measures/__init__.py
+++ b/archetypal/template/measures/__init__.py
@@ -1,0 +1,1 @@
+"""Energy measures module."""

--- a/archetypal/template/measures/boston_default_windows.json
+++ b/archetypal/template/measures/boston_default_windows.json
@@ -1,7 +1,7 @@
 {
   "GasMaterials": [
     {
-      "$id": "1",
+      "$id": "239393209120",
       "Category": "Gases",
       "Type": "AIR",
       "Conductivity": 0.0,
@@ -19,7 +19,7 @@
       "Name": "AIR"
     },
     {
-      "$id": "2",
+      "$id": "239393209121",
       "Category": "Gases",
       "Type": "ARGON",
       "Conductivity": 0.0,
@@ -37,7 +37,7 @@
       "Name": "ARGON"
     },
     {
-      "$id": "3",
+      "$id": "239393209122",
       "Category": "Gases",
       "Type": "KRYPTON",
       "Conductivity": 0.0,
@@ -55,7 +55,7 @@
       "Name": "KRYPTON"
     },
     {
-      "$id": "5",
+      "$id": "239393209123",
       "Category": "Gases",
       "Type": "SF6",
       "Conductivity": 0.0,
@@ -73,7 +73,7 @@
       "Name": "SF6"
     },
     {
-      "$id": "4",
+      "$id": "239393209124",
       "Category": "Gases",
       "Type": "XENON",
       "Conductivity": 0.0,
@@ -93,7 +93,7 @@
   ],
   "GlazingMaterials": [
     {
-      "$id": "7",
+      "$id": "939393209121",
       "DirtFactor": 1.0,
       "IREmissivityBack": 0.84,
       "IREmissivityFront": 0.84,
@@ -122,7 +122,7 @@
       "Name": "B_Glass_Clear_3"
     },
     {
-      "$id": "9",
+      "$id": "939393209122",
       "DirtFactor": 1.0,
       "IREmissivityBack": 0.84,
       "IREmissivityFront": 0.84,
@@ -151,7 +151,7 @@
       "Name": "B_Glass_Clear_3_LoE_1"
     },
     {
-      "$id": "8",
+      "$id": "939393209123",
       "DirtFactor": 1.0,
       "IREmissivityBack": 0.84,
       "IREmissivityFront": 0.84,
@@ -180,7 +180,7 @@
       "Name": "B_Glass_Clear_3_Ref_H"
     },
     {
-      "$id": "6",
+      "$id": "939393209124",
       "DirtFactor": 1.0,
       "IREmissivityBack": 0.84,
       "IREmissivityFront": 0.84,
@@ -211,7 +211,7 @@
   ],
   "OpaqueMaterials": [
     {
-      "$id": "18",
+      "$id": "939393209125",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.7,
@@ -236,7 +236,7 @@
       "Name": "B_Air_Floor_15cm"
     },
     {
-      "$id": "12",
+      "$id": "939393209126",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.7,
@@ -261,7 +261,7 @@
       "Name": "B_Air_Wall_3cm"
     },
     {
-      "$id": "22",
+      "$id": "939393209127",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.8,
@@ -288,7 +288,7 @@
       "Name": "B_Cement_Mortar"
     },
     {
-      "$id": "19",
+      "$id": "939393209128",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.4,
@@ -314,7 +314,7 @@
       "Name": "B_Ceramic_Tile"
     },
     {
-      "$id": "17",
+      "$id": "939393209129",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.5,
@@ -339,7 +339,7 @@
       "Name": "B_Clay_Brick_H"
     },
     {
-      "$id": "11",
+      "$id": "939393209110",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.7,
@@ -364,7 +364,7 @@
       "Name": "B_Concrete_Block_H"
     },
     {
-      "$id": "15",
+      "$id": "939393209111",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.7,
@@ -389,7 +389,7 @@
       "Name": "B_Concrete_Block_S"
     },
     {
-      "$id": "14",
+      "$id": "939393209112",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.7,
@@ -414,7 +414,7 @@
       "Name": "B_Concrete_MC_Light"
     },
     {
-      "$id": "13",
+      "$id": "939393209113",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.7,
@@ -439,7 +439,7 @@
       "Name": "B_Concrete_RC_Dense"
     },
     {
-      "$id": "24",
+      "$id": "939393209114",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.6,
@@ -464,7 +464,7 @@
       "Name": "B_Fiberglass_Batts"
     },
     {
-      "$id": "16",
+      "$id": "939393209115",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.6,
@@ -491,7 +491,7 @@
       "Name": "B_Gypsum_Board"
     },
     {
-      "$id": "21",
+      "$id": "939393209116",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.7,
@@ -518,7 +518,7 @@
       "Name": "B_Gypsum_Plaster"
     },
     {
-      "$id": "26",
+      "$id": "939393209117",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.6,
@@ -545,7 +545,7 @@
       "Name": "B_Hardwood_General"
     },
     {
-      "$id": "23",
+      "$id": "939393209118",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.7,
@@ -570,7 +570,7 @@
       "Name": "B_Plywood_Board"
     },
     {
-      "$id": "28",
+      "$id": "939393209119",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.6,
@@ -595,7 +595,7 @@
       "Name": "B_Slate_Tile"
     },
     {
-      "$id": "27",
+      "$id": "939393209100",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.6,
@@ -622,7 +622,7 @@
       "Name": "B_Softwood_General"
     },
     {
-      "$id": "31",
+      "$id": "939393209101",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.4,
@@ -647,7 +647,7 @@
       "Name": "B_Steel_General"
     },
     {
-      "$id": "25",
+      "$id": "939393209102",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.7,
@@ -672,7 +672,7 @@
       "Name": "B_Urethane_Carpet"
     },
     {
-      "$id": "30",
+      "$id": "939393209103",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.7,
@@ -697,7 +697,7 @@
       "Name": "B_Vinyl_Cladding"
     },
     {
-      "$id": "10",
+      "$id": "939393209104",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.6,
@@ -723,7 +723,7 @@
       "Name": "B_Wood_Floor"
     },
     {
-      "$id": "29",
+      "$id": "939393209105",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.6,
@@ -748,7 +748,7 @@
       "Name": "B_Wood_Shingle"
     },
     {
-      "$id": "20",
+      "$id": "939393209106",
       "MoistureDiffusionResistance": 50.0,
       "Roughness": "Rough",
       "SolarAbsorptance": 0.6,
@@ -778,23 +778,23 @@
   "OpaqueConstructions": [],
   "WindowConstructions": [
     {
-      "$id": "57",
+      "$id": "939393209000",
       "Layers": [
         {
           "Material": {
-            "$ref": "7"
+            "$ref": "939393209121"
           },
           "Thickness": 0.003
         },
         {
           "Material": {
-            "$ref": "1"
+            "$ref": "239393209120"
           },
           "Thickness": 0.006
         },
         {
           "Material": {
-            "$ref": "7"
+            "$ref": "939393209121"
           },
           "Thickness": 0.003
         }
@@ -810,23 +810,23 @@
       "Name": "B_Dbl_Air_Cl"
     },
     {
-      "$id": "58",
+      "$id": "939393209001",
       "Layers": [
         {
           "Material": {
-            "$ref": "9"
+            "$ref": "939393209122"
           },
           "Thickness": 0.003
         },
         {
           "Material": {
-            "$ref": "1"
+            "$ref": "239393209120"
           },
           "Thickness": 0.006
         },
         {
           "Material": {
-            "$ref": "7"
+            "$ref": "939393209121"
           },
           "Thickness": 0.003
         }
@@ -842,23 +842,23 @@
       "Name": "B_Dbl_Air_Le"
     },
     {
-      "$id": "59",
+      "$id": "939393209002",
       "Layers": [
         {
           "Material": {
-            "$ref": "7"
+            "$ref": "939393209121"
           },
           "Thickness": 0.003
         },
         {
           "Material": {
-            "$ref": "2"
+            "$ref": "239393209121"
           },
           "Thickness": 0.006
         },
         {
           "Material": {
-            "$ref": "7"
+            "$ref": "939393209121"
           },
           "Thickness": 0.003
         }
@@ -874,23 +874,23 @@
       "Name": "B_Dbl_Arg_Cl"
     },
     {
-      "$id": "60",
+      "$id": "939393209003",
       "Layers": [
         {
           "Material": {
-            "$ref": "9"
+            "$ref": "939393209122"
           },
           "Thickness": 0.003
         },
         {
           "Material": {
-            "$ref": "2"
+            "$ref": "239393209121"
           },
           "Thickness": 0.006
         },
         {
           "Material": {
-            "$ref": "7"
+            "$ref": "939393209121"
           },
           "Thickness": 0.003
         }
@@ -906,11 +906,11 @@
       "Name": "B_Dbl_Arg_Le"
     },
     {
-      "$id": "61",
+      "$id": "939393209004",
       "Layers": [
         {
           "Material": {
-            "$ref": "6"
+            "$ref": "939393209124"
           },
           "Thickness": 0.004
         }

--- a/archetypal/template/measures/boston_default_windows.json
+++ b/archetypal/template/measures/boston_default_windows.json
@@ -1,0 +1,941 @@
+{
+  "GasMaterials": [
+    {
+      "$id": "1",
+      "Category": "Gases",
+      "Type": "AIR",
+      "Conductivity": 0.0,
+      "Cost": 0.0,
+      "Density": 0.0,
+      "EmbodiedCarbon": 0.0,
+      "EmbodiedEnergy": 0.0,
+      "SubstitutionRatePattern": [],
+      "SubstitutionTimestep": 0.0,
+      "TransportCarbon": 0.0,
+      "TransportDistance": 0.0,
+      "TransportEnergy": 0.0,
+      "Comments": null,
+      "DataSource": null,
+      "Name": "AIR"
+    },
+    {
+      "$id": "2",
+      "Category": "Gases",
+      "Type": "ARGON",
+      "Conductivity": 0.0,
+      "Cost": 0.0,
+      "Density": 0.0,
+      "EmbodiedCarbon": 0.0,
+      "EmbodiedEnergy": 0.0,
+      "SubstitutionRatePattern": [],
+      "SubstitutionTimestep": 0.0,
+      "TransportCarbon": 0.0,
+      "TransportDistance": 0.0,
+      "TransportEnergy": 0.0,
+      "Comments": null,
+      "DataSource": null,
+      "Name": "ARGON"
+    },
+    {
+      "$id": "3",
+      "Category": "Gases",
+      "Type": "KRYPTON",
+      "Conductivity": 0.0,
+      "Cost": 0.0,
+      "Density": 0.0,
+      "EmbodiedCarbon": 0.0,
+      "EmbodiedEnergy": 0.0,
+      "SubstitutionRatePattern": [],
+      "SubstitutionTimestep": 0.0,
+      "TransportCarbon": 0.0,
+      "TransportDistance": 0.0,
+      "TransportEnergy": 0.0,
+      "Comments": null,
+      "DataSource": null,
+      "Name": "KRYPTON"
+    },
+    {
+      "$id": "5",
+      "Category": "Gases",
+      "Type": "SF6",
+      "Conductivity": 0.0,
+      "Cost": 0.0,
+      "Density": 0.0,
+      "EmbodiedCarbon": 0.0,
+      "EmbodiedEnergy": 0.0,
+      "SubstitutionRatePattern": [],
+      "SubstitutionTimestep": 0.0,
+      "TransportCarbon": 0.0,
+      "TransportDistance": 0.0,
+      "TransportEnergy": 0.0,
+      "Comments": null,
+      "DataSource": null,
+      "Name": "SF6"
+    },
+    {
+      "$id": "4",
+      "Category": "Gases",
+      "Type": "XENON",
+      "Conductivity": 0.0,
+      "Cost": 0.0,
+      "Density": 0.0,
+      "EmbodiedCarbon": 0.0,
+      "EmbodiedEnergy": 0.0,
+      "SubstitutionRatePattern": [],
+      "SubstitutionTimestep": 0.0,
+      "TransportCarbon": 0.0,
+      "TransportDistance": 0.0,
+      "TransportEnergy": 0.0,
+      "Comments": null,
+      "DataSource": null,
+      "Name": "XENON"
+    }
+  ],
+  "GlazingMaterials": [
+    {
+      "$id": "7",
+      "DirtFactor": 1.0,
+      "IREmissivityBack": 0.84,
+      "IREmissivityFront": 0.84,
+      "IRTransmittance": 0.01,
+      "SolarReflectanceBack": 0.07,
+      "SolarReflectanceFront": 0.07,
+      "SolarTransmittance": 0.83,
+      "VisibleReflectanceBack": 0.08,
+      "VisibleReflectanceFront": 0.08,
+      "VisibleTransmittance": 0.89,
+      "Conductivity": 0.9,
+      "Cost": 0.0,
+      "Density": 2500.0,
+      "EmbodiedCarbon": 5.06,
+      "EmbodiedEnergy": 96.1,
+      "SubstitutionRatePattern": [
+        0.2
+      ],
+      "SubstitutionTimestep": 50.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Glass_Clear_3"
+    },
+    {
+      "$id": "9",
+      "DirtFactor": 1.0,
+      "IREmissivityBack": 0.84,
+      "IREmissivityFront": 0.84,
+      "IRTransmittance": 0.01,
+      "SolarReflectanceBack": 0.22,
+      "SolarReflectanceFront": 0.19,
+      "SolarTransmittance": 0.63,
+      "VisibleReflectanceBack": 0.08,
+      "VisibleReflectanceFront": 0.06,
+      "VisibleTransmittance": 0.85,
+      "Conductivity": 0.9,
+      "Cost": 0.0,
+      "Density": 2500.0,
+      "EmbodiedCarbon": 5.06,
+      "EmbodiedEnergy": 96.1,
+      "SubstitutionRatePattern": [
+        0.2
+      ],
+      "SubstitutionTimestep": 50.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Glass_Clear_3_LoE_1"
+    },
+    {
+      "$id": "8",
+      "DirtFactor": 1.0,
+      "IREmissivityBack": 0.84,
+      "IREmissivityFront": 0.84,
+      "IRTransmittance": 0.01,
+      "SolarReflectanceBack": 0.43,
+      "SolarReflectanceFront": 0.27,
+      "SolarTransmittance": 0.11,
+      "VisibleReflectanceBack": 0.35,
+      "VisibleReflectanceFront": 0.31,
+      "VisibleTransmittance": 0.14,
+      "Conductivity": 0.9,
+      "Cost": 0.0,
+      "Density": 2500.0,
+      "EmbodiedCarbon": 5.06,
+      "EmbodiedEnergy": 96.1,
+      "SubstitutionRatePattern": [
+        0.2
+      ],
+      "SubstitutionTimestep": 50.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Glass_Clear_3_Ref_H"
+    },
+    {
+      "$id": "6",
+      "DirtFactor": 1.0,
+      "IREmissivityBack": 0.84,
+      "IREmissivityFront": 0.84,
+      "IRTransmittance": 0.01,
+      "SolarReflectanceBack": 0.07,
+      "SolarReflectanceFront": 0.07,
+      "SolarTransmittance": 0.83,
+      "VisibleReflectanceBack": 0.08,
+      "VisibleReflectanceFront": 0.08,
+      "VisibleTransmittance": 0.89,
+      "Conductivity": 0.9,
+      "Cost": 0.0,
+      "Density": 2500.0,
+      "EmbodiedCarbon": 10.1,
+      "EmbodiedEnergy": 191.8,
+      "SubstitutionRatePattern": [
+        0.2
+      ],
+      "SubstitutionTimestep": 50.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Glass_Clear_4"
+    }
+  ],
+  "OpaqueMaterials": [
+    {
+      "$id": "18",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.7,
+      "SpecificHeat": 1000.0,
+      "ThermalEmittance": 0.01,
+      "VisibleAbsorptance": 0.7,
+      "Conductivity": 0.7,
+      "Cost": 0.0,
+      "Density": 1.2,
+      "EmbodiedCarbon": 0.0,
+      "EmbodiedEnergy": 0.0,
+      "SubstitutionRatePattern": [
+        1.0
+      ],
+      "SubstitutionTimestep": 100.0,
+      "TransportCarbon": 0.0,
+      "TransportDistance": 0.0,
+      "TransportEnergy": 0.0,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Air_Floor_15cm"
+    },
+    {
+      "$id": "12",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.7,
+      "SpecificHeat": 1000.0,
+      "ThermalEmittance": 0.01,
+      "VisibleAbsorptance": 0.7,
+      "Conductivity": 0.1,
+      "Cost": 0.0,
+      "Density": 1.2,
+      "EmbodiedCarbon": 0.0,
+      "EmbodiedEnergy": 0.0,
+      "SubstitutionRatePattern": [
+        1.0
+      ],
+      "SubstitutionTimestep": 100.0,
+      "TransportCarbon": 0.0,
+      "TransportDistance": 0.0,
+      "TransportEnergy": 0.0,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Air_Wall_3cm"
+    },
+    {
+      "$id": "22",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.8,
+      "SpecificHeat": 840.0,
+      "ThermalEmittance": 0.9,
+      "VisibleAbsorptance": 0.8,
+      "Conductivity": 0.8,
+      "Cost": 0.0,
+      "Density": 1900.0,
+      "EmbodiedCarbon": 0.18,
+      "EmbodiedEnergy": 1.34,
+      "SubstitutionRatePattern": [
+        0.02,
+        0.1,
+        1.0
+      ],
+      "SubstitutionTimestep": 20.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Cement_Mortar"
+    },
+    {
+      "$id": "19",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.4,
+      "SpecificHeat": 840.0,
+      "ThermalEmittance": 0.9,
+      "VisibleAbsorptance": 0.4,
+      "Conductivity": 0.8,
+      "Cost": 0.0,
+      "Density": 2243.0,
+      "EmbodiedCarbon": 0.59,
+      "EmbodiedEnergy": 9.0,
+      "SubstitutionRatePattern": [
+        0.5,
+        1.0
+      ],
+      "SubstitutionTimestep": 20.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Ceramic_Tile"
+    },
+    {
+      "$id": "17",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.5,
+      "SpecificHeat": 920.0,
+      "ThermalEmittance": 0.9,
+      "VisibleAbsorptance": 0.5,
+      "Conductivity": 0.41,
+      "Cost": 0.0,
+      "Density": 1000.0,
+      "EmbodiedCarbon": 0.22,
+      "EmbodiedEnergy": 3.0,
+      "SubstitutionRatePattern": [
+        0.2
+      ],
+      "SubstitutionTimestep": 50.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Clay_Brick_H"
+    },
+    {
+      "$id": "11",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.7,
+      "SpecificHeat": 840.0,
+      "ThermalEmittance": 0.9,
+      "VisibleAbsorptance": 0.7,
+      "Conductivity": 1.25,
+      "Cost": 0.0,
+      "Density": 880.0,
+      "EmbodiedCarbon": 0.08,
+      "EmbodiedEnergy": 0.71,
+      "SubstitutionRatePattern": [
+        0.2
+      ],
+      "SubstitutionTimestep": 50.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Concrete_Block_H"
+    },
+    {
+      "$id": "15",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.7,
+      "SpecificHeat": 840.0,
+      "ThermalEmittance": 0.9,
+      "VisibleAbsorptance": 0.7,
+      "Conductivity": 1.77,
+      "Cost": 0.0,
+      "Density": 1900.0,
+      "EmbodiedCarbon": 0.08,
+      "EmbodiedEnergy": 0.71,
+      "SubstitutionRatePattern": [
+        0.2
+      ],
+      "SubstitutionTimestep": 50.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Concrete_Block_S"
+    },
+    {
+      "$id": "14",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.7,
+      "SpecificHeat": 1040.0,
+      "ThermalEmittance": 0.9,
+      "VisibleAbsorptance": 0.7,
+      "Conductivity": 1.65,
+      "Cost": 0.0,
+      "Density": 2100.0,
+      "EmbodiedCarbon": 0.24,
+      "EmbodiedEnergy": 2.12,
+      "SubstitutionRatePattern": [
+        1.0
+      ],
+      "SubstitutionTimestep": 100.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Concrete_MC_Light"
+    },
+    {
+      "$id": "13",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.7,
+      "SpecificHeat": 840.0,
+      "ThermalEmittance": 0.9,
+      "VisibleAbsorptance": 0.7,
+      "Conductivity": 1.75,
+      "Cost": 0.0,
+      "Density": 2400.0,
+      "EmbodiedCarbon": 0.24,
+      "EmbodiedEnergy": 2.12,
+      "SubstitutionRatePattern": [
+        1.0
+      ],
+      "SubstitutionTimestep": 100.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Concrete_RC_Dense"
+    },
+    {
+      "$id": "24",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.6,
+      "SpecificHeat": 840.0,
+      "ThermalEmittance": 0.9,
+      "VisibleAbsorptance": 0.6,
+      "Conductivity": 0.043,
+      "Cost": 0.0,
+      "Density": 12.0,
+      "EmbodiedCarbon": 1.35,
+      "EmbodiedEnergy": 28.0,
+      "SubstitutionRatePattern": [
+        0.5
+      ],
+      "SubstitutionTimestep": 30.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 1000.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Fiberglass_Batts"
+    },
+    {
+      "$id": "16",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.6,
+      "SpecificHeat": 840.0,
+      "ThermalEmittance": 0.9,
+      "VisibleAbsorptance": 0.6,
+      "Conductivity": 0.16,
+      "Cost": 0.0,
+      "Density": 950.0,
+      "EmbodiedCarbon": 0.38,
+      "EmbodiedEnergy": 6.75,
+      "SubstitutionRatePattern": [
+        0.02,
+        0.1,
+        1.0
+      ],
+      "SubstitutionTimestep": 20.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Gypsum_Board"
+    },
+    {
+      "$id": "21",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.7,
+      "SpecificHeat": 840.0,
+      "ThermalEmittance": 0.9,
+      "VisibleAbsorptance": 0.7,
+      "Conductivity": 0.42,
+      "Cost": 0.0,
+      "Density": 900.0,
+      "EmbodiedCarbon": 0.24,
+      "EmbodiedEnergy": 3.2,
+      "SubstitutionRatePattern": [
+        0.02,
+        0.1,
+        1.0
+      ],
+      "SubstitutionTimestep": 20.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Gypsum_Plaster"
+    },
+    {
+      "$id": "26",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.6,
+      "SpecificHeat": 1630.0,
+      "ThermalEmittance": 0.9,
+      "VisibleAbsorptance": 0.6,
+      "Conductivity": 0.16,
+      "Cost": 0.0,
+      "Density": 680.0,
+      "EmbodiedCarbon": 0.45,
+      "EmbodiedEnergy": 7.5,
+      "SubstitutionRatePattern": [
+        0.1,
+        0.1,
+        1.0
+      ],
+      "SubstitutionTimestep": 20.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Hardwood_General"
+    },
+    {
+      "$id": "23",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.7,
+      "SpecificHeat": 1880.0,
+      "ThermalEmittance": 0.9,
+      "VisibleAbsorptance": 0.7,
+      "Conductivity": 0.11,
+      "Cost": 0.0,
+      "Density": 540.0,
+      "EmbodiedCarbon": 0.81,
+      "EmbodiedEnergy": 15.0,
+      "SubstitutionRatePattern": [
+        0.2
+      ],
+      "SubstitutionTimestep": 30.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Plywood_Board"
+    },
+    {
+      "$id": "28",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.6,
+      "SpecificHeat": 1260.0,
+      "ThermalEmittance": 0.9,
+      "VisibleAbsorptance": 0.6,
+      "Conductivity": 1.59,
+      "Cost": 0.0,
+      "Density": 1920.0,
+      "EmbodiedCarbon": 0.032,
+      "EmbodiedEnergy": 0.55,
+      "SubstitutionRatePattern": [
+        1.0
+      ],
+      "SubstitutionTimestep": 30.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Slate_Tile"
+    },
+    {
+      "$id": "27",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.6,
+      "SpecificHeat": 1630.0,
+      "ThermalEmittance": 0.9,
+      "VisibleAbsorptance": 0.6,
+      "Conductivity": 0.13,
+      "Cost": 0.0,
+      "Density": 496.0,
+      "EmbodiedCarbon": 0.45,
+      "EmbodiedEnergy": 7.5,
+      "SubstitutionRatePattern": [
+        0.1,
+        0.1,
+        1.0
+      ],
+      "SubstitutionTimestep": 20.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Softwood_General"
+    },
+    {
+      "$id": "31",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.4,
+      "SpecificHeat": 500.0,
+      "ThermalEmittance": 0.9,
+      "VisibleAbsorptance": 0.4,
+      "Conductivity": 45.3,
+      "Cost": 0.0,
+      "Density": 7830.0,
+      "EmbodiedCarbon": 1.37,
+      "EmbodiedEnergy": 20.1,
+      "SubstitutionRatePattern": [
+        1.0
+      ],
+      "SubstitutionTimestep": 100.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Steel_General"
+    },
+    {
+      "$id": "25",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.7,
+      "SpecificHeat": 840.0,
+      "ThermalEmittance": 0.9,
+      "VisibleAbsorptance": 0.7,
+      "Conductivity": 0.045,
+      "Cost": 0.0,
+      "Density": 110.0,
+      "EmbodiedCarbon": 3.89,
+      "EmbodiedEnergy": 74.4,
+      "SubstitutionRatePattern": [
+        1.0
+      ],
+      "SubstitutionTimestep": 5.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 1000.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Urethane_Carpet"
+    },
+    {
+      "$id": "30",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.7,
+      "SpecificHeat": 1000.0,
+      "ThermalEmittance": 0.9,
+      "VisibleAbsorptance": 0.7,
+      "Conductivity": 0.16,
+      "Cost": 0.0,
+      "Density": 1380.0,
+      "EmbodiedCarbon": 2.41,
+      "EmbodiedEnergy": 77.2,
+      "SubstitutionRatePattern": [
+        1.0
+      ],
+      "SubstitutionTimestep": 20.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Vinyl_Cladding"
+    },
+    {
+      "$id": "10",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.6,
+      "SpecificHeat": 1200.0,
+      "ThermalEmittance": 0.85,
+      "VisibleAbsorptance": 0.6,
+      "Conductivity": 0.14,
+      "Cost": 0.0,
+      "Density": 650.0,
+      "EmbodiedCarbon": 0.45,
+      "EmbodiedEnergy": 7.4,
+      "SubstitutionRatePattern": [
+        0.5,
+        1.0
+      ],
+      "SubstitutionTimestep": 20.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Wood_Floor"
+    },
+    {
+      "$id": "29",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.6,
+      "SpecificHeat": 1300.0,
+      "ThermalEmittance": 0.9,
+      "VisibleAbsorptance": 0.6,
+      "Conductivity": 0.04,
+      "Cost": 0.0,
+      "Density": 592.0,
+      "EmbodiedCarbon": 0.47,
+      "EmbodiedEnergy": 7.8,
+      "SubstitutionRatePattern": [
+        1.0
+      ],
+      "SubstitutionTimestep": 30.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_Wood_Shingle"
+    },
+    {
+      "$id": "20",
+      "MoistureDiffusionResistance": 50.0,
+      "Roughness": "Rough",
+      "SolarAbsorptance": 0.6,
+      "SpecificHeat": 1200.0,
+      "ThermalEmittance": 0.6,
+      "VisibleAbsorptance": 0.6,
+      "Conductivity": 0.037,
+      "Cost": 0.0,
+      "Density": 40.0,
+      "EmbodiedCarbon": 2.7,
+      "EmbodiedEnergy": 86.4,
+      "SubstitutionRatePattern": [
+        0.02,
+        0.1,
+        1.0
+      ],
+      "SubstitutionTimestep": 20.0,
+      "TransportCarbon": 0.067,
+      "TransportDistance": 500.0,
+      "TransportEnergy": 0.94,
+      "Category": "Uncategorized",
+      "Comments": null,
+      "DataSource": "default",
+      "Name": "B_XPS_Board"
+    }
+  ],
+  "OpaqueConstructions": [],
+  "WindowConstructions": [
+    {
+      "$id": "57",
+      "Layers": [
+        {
+          "Material": {
+            "$ref": "7"
+          },
+          "Thickness": 0.003
+        },
+        {
+          "Material": {
+            "$ref": "1"
+          },
+          "Thickness": 0.006
+        },
+        {
+          "Material": {
+            "$ref": "7"
+          },
+          "Thickness": 0.003
+        }
+      ],
+      "AssemblyCarbon": 0.0,
+      "AssemblyCost": 0.0,
+      "AssemblyEnergy": 0.0,
+      "DisassemblyCarbon": 0.0,
+      "DisassemblyEnergy": 0.0,
+      "Category": "Double",
+      "Comments": "default",
+      "DataSource": "default",
+      "Name": "B_Dbl_Air_Cl"
+    },
+    {
+      "$id": "58",
+      "Layers": [
+        {
+          "Material": {
+            "$ref": "9"
+          },
+          "Thickness": 0.003
+        },
+        {
+          "Material": {
+            "$ref": "1"
+          },
+          "Thickness": 0.006
+        },
+        {
+          "Material": {
+            "$ref": "7"
+          },
+          "Thickness": 0.003
+        }
+      ],
+      "AssemblyCarbon": 0.0,
+      "AssemblyCost": 0.0,
+      "AssemblyEnergy": 0.0,
+      "DisassemblyCarbon": 0.0,
+      "DisassemblyEnergy": 0.0,
+      "Category": "Double",
+      "Comments": "default",
+      "DataSource": "default",
+      "Name": "B_Dbl_Air_Le"
+    },
+    {
+      "$id": "59",
+      "Layers": [
+        {
+          "Material": {
+            "$ref": "7"
+          },
+          "Thickness": 0.003
+        },
+        {
+          "Material": {
+            "$ref": "2"
+          },
+          "Thickness": 0.006
+        },
+        {
+          "Material": {
+            "$ref": "7"
+          },
+          "Thickness": 0.003
+        }
+      ],
+      "AssemblyCarbon": 0.0,
+      "AssemblyCost": 0.0,
+      "AssemblyEnergy": 0.0,
+      "DisassemblyCarbon": 0.0,
+      "DisassemblyEnergy": 0.0,
+      "Category": "Double",
+      "Comments": "default",
+      "DataSource": "default",
+      "Name": "B_Dbl_Arg_Cl"
+    },
+    {
+      "$id": "60",
+      "Layers": [
+        {
+          "Material": {
+            "$ref": "9"
+          },
+          "Thickness": 0.003
+        },
+        {
+          "Material": {
+            "$ref": "2"
+          },
+          "Thickness": 0.006
+        },
+        {
+          "Material": {
+            "$ref": "7"
+          },
+          "Thickness": 0.003
+        }
+      ],
+      "AssemblyCarbon": 0.0,
+      "AssemblyCost": 0.0,
+      "AssemblyEnergy": 0.0,
+      "DisassemblyCarbon": 0.0,
+      "DisassemblyEnergy": 0.0,
+      "Category": "Double",
+      "Comments": "default",
+      "DataSource": "default",
+      "Name": "B_Dbl_Arg_Le"
+    },
+    {
+      "$id": "61",
+      "Layers": [
+        {
+          "Material": {
+            "$ref": "6"
+          },
+          "Thickness": 0.004
+        }
+      ],
+      "AssemblyCarbon": 0.0,
+      "AssemblyCost": 0.0,
+      "AssemblyEnergy": 0.0,
+      "DisassemblyCarbon": 0.0,
+      "DisassemblyEnergy": 0.0,
+      "Category": "Single",
+      "Comments": "default",
+      "DataSource": "default",
+      "Name": "B_Sng_Cl"
+    }
+  ],
+  "StructureDefinitions": [],
+  "DaySchedules": [],
+  "WeekSchedules": [],
+  "YearSchedules": [],
+  "DomesticHotWaterSettings": [],
+  "VentilationSettings": [],
+  "ZoneConditionings": [],
+  "ZoneConstructionSets": [],
+  "ZoneLoads": [],
+  "Zones": [],
+  "WindowSettings": [],
+  "BuildingTemplates": []
+}

--- a/archetypal/template/measures/default_insulation.json
+++ b/archetypal/template/measures/default_insulation.json
@@ -1,0 +1,25 @@
+{
+  "$id": "0234183819",
+  "MoistureDiffusionResistance": 50.0,
+  "Roughness": "Rough",
+  "SolarAbsorptance": 0.6,
+  "SpecificHeat": 840.0,
+  "ThermalEmittance": 0.9,
+  "VisibleAbsorptance": 0.6,
+  "Conductivity": 0.043,
+  "Cost": 0.0,
+  "Density": 12.0,
+  "EmbodiedCarbon": 1.35,
+  "EmbodiedEnergy": 28.0,
+  "SubstitutionRatePattern": [
+    0.5
+  ],
+  "SubstitutionTimestep": 30.0,
+  "TransportCarbon": 0.067,
+  "TransportDistance": 1000.0,
+  "TransportEnergy": 0.94,
+  "Category": "Uncategorized",
+  "Comments": null,
+  "DataSource": "default",
+  "Name": "B_Fiberglass_Batts"
+}

--- a/archetypal/template/measures/measure.py
+++ b/archetypal/template/measures/measure.py
@@ -149,7 +149,7 @@ class MeasureAction:
 
     @property
     def Transformer(self):
-        """Get or set a measure action transformer """
+        """Get or set a measure action transformer"""
 
         return self._transformer
 
@@ -402,7 +402,7 @@ class MeasureProperty:
 
     @property
     def Validator(self):
-        """Get or set a measure property validator """
+        """Get or set a measure property validator"""
         return self._validator
 
     @Validator.setter
@@ -1120,7 +1120,7 @@ class SetFacadeThermalResistance(Measure):
     _name = "Facade Upgrade"
     _description = "Upgrade roof and facade insulation by specifying R-Values for entire assemblies."
 
-    def __init__(self, RoofRValue=1/2.37, FacadeRValue=1/1.66, **kwargs):
+    def __init__(self, RoofRValue=1 / 2.37, FacadeRValue=1 / 1.66, **kwargs):
 
         super(SetFacadeThermalResistance, self).__init__(**kwargs)
         roof_property = MeasureProperty(
@@ -1228,66 +1228,72 @@ class InstallDoublePaneWindowsWithFixedUValueAndCoating(Measure):
     _description = "Upgrade windows to fixed double pane window"
 
     def __init__(self, AirGapThickness=0.080, IsLowE=True, Gas="AIR", **kwargs):
-        super(InstallDoublePaneWindowsWithFixedUValueAndCoating, self).__init__(**kwargs)
+        super(InstallDoublePaneWindowsWithFixedUValueAndCoating, self).__init__(
+            **kwargs
+        )
 
-        def create_double_pane_window( AirGapThickness, IsLowE, Gas):
-            location = os.path.join(os.path.dirname(os.path.abspath(__file__)), "boston_default_windows.json")
+        def create_double_pane_window(AirGapThickness, IsLowE, Gas):
+            location = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                "boston_default_windows.json",
+            )
             window_lib = UmiTemplateLibrary.open(location)
             gasOffset = 0
-            if (Gas.lower() == "air"):
+            if Gas.lower() == "air":
                 pass
-            elif (Gas.lower() == "argon"):
+            elif Gas.lower() == "argon":
                 gasOffset = 2
             else:
                 raise ValueError("Unsupported gas specified.")
             lowEOffset = 0
-            if (not IsLowE):
+            if not IsLowE:
                 pass
-            elif (IsLowE):
+            elif IsLowE:
                 lowEOffset = 1
 
-            window = window_lib.WindowConstructions[gasOffset+lowEOffset]
+            window = window_lib.WindowConstructions[gasOffset + lowEOffset]
 
             window.Layers[1].Thickness = AirGapThickness
             return window
-            
-        
+
         def WindowReplacer(original_value, proposed_transformer_value, *args, **kwargs):
-            return create_double_pane_window(self.AirGapThickness, self.IsLowE, self.Gas)
+            return create_double_pane_window(
+                self.AirGapThickness, self.IsLowE, self.Gas
+            )
 
         window_replacement_action = MeasureAction(
             Name="Replace Window",
             Lookup=["Windows", "Construction"],
             Transformer=WindowReplacer,
         )
-        
+
         window_replacement_property = MeasureProperty(
             Name="Window Replacer",
             AttrName="WindowReplacer",
             Description="Replaces the window construction",
             Default=None,
-            Actions=[window_replacement_action]
+            Actions=[window_replacement_action],
         )
         window_gas_prop = MeasureProperty(
             Name="Gas",
             AttrName="Gas",
             Description="Select the gas layer",
             Default=Gas,
-            Actions=[]
+            Actions=[],
         )
         window_lowe_prop = MeasureProperty(
             Name="Is LowE",
             AttrName="IsLowE",
             Description="Adds a low-e coating",
             Default=IsLowE,
-            Actions=[]
+            Actions=[],
         )
         window_airgap_property = MeasureProperty(
             Name="Air Gap Thickness",
             AttrName="AirGapThickness",
             Description="Change the airgap thickness",
             Default=AirGapThickness,
-            Actions=[]
+            Actions=[],
         )
         self.add_property(window_replacement_property)
         self.add_property(window_gas_prop)
@@ -1304,15 +1310,20 @@ class AddInsulationIfItDoesNotExistOrUpgrade(Measure):
         super(AddInsulationIfItDoesNotExistOrUpgrade, self).__init__(**kwargs)
 
         def create_insulation_material():
-            location = os.path.join(os.path.dirname(os.path.abspath(__file__)), "default_insulation.json")
+            location = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), "default_insulation.json"
+            )
             data = {}
             with open(location) as f:
                 data = json.load(f)
             insulation_material = OpaqueMaterial.from_dict(data)
             return insulation_material
 
-        def AddInsulationLayerAndSetRValue(original_value, proposed_transformer_value, *args, **kwargs):
+        def AddInsulationLayerAndSetRValue(
+            original_value, proposed_transformer_value, *args, **kwargs
+        ):
             from archetypal.template.materials.material_layer import MaterialLayer
+
             mat = create_insulation_material()
             layer = MaterialLayer(mat, 0.060)
             new = original_value.duplicate()
@@ -1325,13 +1336,13 @@ class AddInsulationIfItDoesNotExistOrUpgrade(Measure):
             Lookup=["Perimeter", "Constructions", "Facade"],
             Transformer=AddInsulationLayerAndSetRValue,
         )
-        
-        facade_insulation_creation_prop= MeasureProperty(
+
+        facade_insulation_creation_prop = MeasureProperty(
             Name="Facade R-Value",
             AttrName="FacadeRValue",
             Description="Adds an insulation layer if none exists, then set r-value of entire assembly.",
             Default=FacadeRValue,
-            Actions=[facade_insulation_addition]
+            Actions=[facade_insulation_addition],
         )
         self.add_property(facade_insulation_creation_prop)
 
@@ -1340,12 +1351,12 @@ class AddInsulationIfItDoesNotExistOrUpgrade(Measure):
             Lookup=["Perimeter", "Constructions", "Roof"],
             Transformer=AddInsulationLayerAndSetRValue,
         )
-        
-        roof_insulation_creation_prop= MeasureProperty(
+
+        roof_insulation_creation_prop = MeasureProperty(
             Name="Roof R-Value",
             AttrName="RoofRValue",
             Description="Adds an insulation layer if none exists, then set r-value of entire assembly.",
             Default=RoofRValue,
-            Actions=[roof_insulation_addition]
+            Actions=[roof_insulation_addition],
         )
         self.add_property(roof_insulation_creation_prop)

--- a/archetypal/template/measures/measure.py
+++ b/archetypal/template/measures/measure.py
@@ -1312,13 +1312,11 @@ class AddInsulationIfItDoesNotExistOrUpgrade(Measure):
             return insulation_material
 
         def AddInsulationLayerAndSetRValue(original_value, proposed_transformer_value, *args, **kwargs):
+            from archetypal.template.materials.material_layer import MaterialLayer
+            mat = create_insulation_material()
+            layer = MaterialLayer(mat, 0.060)
             new = original_value.duplicate()
-            if len(original_value.Layers) == 1:
-                from archetypal.template.materials.material_layer import MaterialLayer
-                mat = create_insulation_material()
-                layer = MaterialLayer(mat, 0.060)
-                new = original_value.duplicate()
-                new.Layers.append(layer)
+            new.Layers.append(layer)
             new.r_value = proposed_transformer_value
             return new
 

--- a/archetypal/template/measures/measure.py
+++ b/archetypal/template/measures/measure.py
@@ -517,8 +517,6 @@ class Measure(object):
 
     # TODO: Write change log functions
     # TODO: Write Properties / Actions getters
-    # TODO: Add methods for adding measures together, extending with more properties, etc
-    # TODO: abstract inheritance classes into presets objects
     __slots__ = (
         "_name",
         "_description",
@@ -526,10 +524,7 @@ class Measure(object):
     )
 
     def __init__(self, Name="Measure", Description="Upgrade Templates", Properties=[]):
-        # TODO: Get multi-class and nested inheritance working
         super().__setattr__("_properties", set())
-        if not hasattr(self, "_properties"):
-            self._properties = set()
 
         self.Name = Name or self._name
         self.Description = Description or self._description

--- a/archetypal/template/measures/measure.py
+++ b/archetypal/template/measures/measure.py
@@ -651,6 +651,39 @@ class Measure(object):
         else:
             super().__getattr__(attr_name)
 
+    @property
+    def Properties(self):
+        """Get or set the measure's properties"""
+        return self._properties
+
+    @Properties.setter
+    def Properties(self, Properties):
+        """Get or set the measure's properties"""
+        self._properties = set()
+        if isinstance(Properties, MeasureProperty):
+            Properties = [Properties]
+        for prop in Properties:
+            print(f"adding a prop - {prop}")
+            self.add_property(prop)
+
+    @property
+    def PropNames(self):
+        return [prop.Name for prop in self]
+
+    @property
+    def PropAttrs(self):
+        return [prop.AttrName for prop in self]
+
+    def get_property(self, AttrName=None, Name=None):
+        if AttrName:
+            return self._get_property_by_attr_name(AttrName)
+        else:
+            return self._get_property_by_name(Name)
+
+    def remove_property(self, AttrName=None, Name=None):
+        prop = self.get_property(AttrName, Name)
+        self._properties.remove(prop)
+
     def add_property(self, prop):
         """Add a property to a measure
 
@@ -691,7 +724,7 @@ class Measure(object):
         """Report a changelog for all BuildingTemplates in target without mutation
         Args:
             target (BuildingTemplate or UmiTemplateLibrary): The object to report changelog for
-        
+
         Returns:
             changelog: dict<BuildingTemplate, (List of str, value, value)
         """

--- a/archetypal/template/measures/measure.py
+++ b/archetypal/template/measures/measure.py
@@ -4,8 +4,8 @@ import inspect
 import logging
 
 from archetypal.template.building_template import BuildingTemplate
-from archetypal.umi_template import UmiTemplateLibrary
 from archetypal.template.schedule import UmiSchedule
+from archetypal.umi_template import UmiTemplateLibrary
 
 log = logging.getLogger(__name__)
 
@@ -318,7 +318,7 @@ class MeasureProperty:
         "_value",
         "_actions",
         "_transformer",
-        "_validator"
+        "_validator",
     )
 
     def __init__(
@@ -330,7 +330,7 @@ class MeasureProperty:
         Transformer=None,
         Validator=None,
         Actions=None,
-        Lookup=None
+        Lookup=None,
     ):
         assert isinstance(Name, str)
         assert isinstance(AttrName, str) and AttrName.isidentifier()
@@ -350,10 +350,7 @@ class MeasureProperty:
 
         self.Value = Default
         if Lookup is not None:
-            action = MeasureAction(
-                Name=self.Name,
-                Lookup=Lookup
-            )
+            action = MeasureAction(Name=self.Name, Lookup=Lookup)
             self.add_action(action)
 
     @property
@@ -759,14 +756,13 @@ class SetMechanicalVentilation(Measure):
             )
         )
 
-
         # Configure schedule actions
         ventilation_schedule_property = MeasureProperty(
             Name="Ventilation Schedule",
             AttrName="VentilationSchedule",
             Description="Set Ventilation Schedule",
             Default=VentilationSchedule,
-            Validator=lambda new_value, **kwargs: isinstance(new_value, UmiSchedule)
+            Validator=lambda new_value, **kwargs: isinstance(new_value, UmiSchedule),
         )
         ventilation_schedule_property.add_action(
             MeasureAction(
@@ -784,7 +780,6 @@ class SetMechanicalVentilation(Measure):
         self.add_property(ventilation_ach_property)
         self.add_property(ventilation_boolean_property)
         self.add_property(ventilation_schedule_property)
-
 
 
 class SetCOP(Measure):
@@ -1065,8 +1060,8 @@ class SetFacadeThermalResistance(Measure):
 
 class SetInfiltration(Measure):
 
-    _name = ("Set Infiltration",)
-    _description = ("This measure sets the infiltration ACH of the perimeter zone.",)
+    _name = "Set Infiltration"
+    _description = "This measure sets the infiltration ACH of the perimeter zone."
 
     def __init__(self, Infiltration=0.6, **kwargs):
         infiltration_action = MeasureAction(

--- a/archetypal/template/measures/measure.py
+++ b/archetypal/template/measures/measure.py
@@ -329,7 +329,7 @@ class MeasureProperty:
         Default,
         Transformer=None,
         Validator=None,
-        actions=None,
+        Actions=None,
         Lookup=None
     ):
         assert isinstance(Name, str)
@@ -342,10 +342,10 @@ class MeasureProperty:
         self.Transformer = Transformer
         self.Validator = Validator
 
-        if isinstance(actions, MeasureAction):
-            actions = [actions]
+        if isinstance(Actions, MeasureAction):
+            Actions = [Actions]
         self._actions = set()
-        for action in actions or []:
+        for action in Actions or []:
             self.add_action(action)
 
         self.Value = Default
@@ -1079,7 +1079,7 @@ class SetInfiltration(Measure):
             AttrName="Infiltration",
             Description="Set Infiltration ACH",
             Default=Infiltration,
-            actions=infiltration_action,
+            Actions=infiltration_action,
         )
 
         super().__init__(Properties=infiltration_property)

--- a/archetypal/template/measures/measure.py
+++ b/archetypal/template/measures/measure.py
@@ -330,14 +330,15 @@ class MeasureProperty:
         Transformer=None,
         Validator=None,
         actions=None,
+        Lookup=None
     ):
         assert isinstance(Name, str)
         assert isinstance(AttrName, str) and AttrName.isidentifier()
         self._name = Name
         self._attr_name = AttrName
-        self._actions = set()
         self._description = Description
-        self._default = Default
+        self._actions = set()
+        self.Default = Default
         self.Transformer = Transformer
         self.Validator = Validator
 
@@ -347,7 +348,13 @@ class MeasureProperty:
         for action in actions or []:
             self.add_action(action)
 
-        self._value = Default
+        self.Value = Default
+        if Lookup is not None:
+            action = MeasureAction(
+                Name=self.Name,
+                Lookup=Lookup
+            )
+            self.add_action(action)
 
     @property
     def Name(self):

--- a/archetypal/template/measures/measure.py
+++ b/archetypal/template/measures/measure.py
@@ -827,6 +827,7 @@ class Measure(object):
                 **kwargs,
             )
             mutations[bt] = bt_mutations
+        library.update_components_list()
         return mutations
 
 

--- a/archetypal/template/measures/measure.py
+++ b/archetypal/template/measures/measure.py
@@ -3,6 +3,8 @@ import functools
 import logging
 
 from archetypal.template.materials.material_layer import MaterialLayer
+from archetypal.template.building_template import BuildingTemplate
+from archetypal.umi_template import UmiTemplateLibrary
 
 log = logging.getLogger(__name__)
 
@@ -53,416 +55,819 @@ def set_path(root, address, value):
         setattr(target, parameter, value)
 
 
-class Measure:
+class MeasureAction:
+    """Stores an Archetypal parameter (or lookup) which 
+       can be associated with a measure 
+    Args:
+    """
+
+    def __init__(self, Name, object_address, validator=None, transformer=None):
+        self._name = Name # Names are not mutable
+        assert callable(object_address) or isinstance(object_address, list), "Object address must be a function, list"
+        self._object_address = object_address
+        # TODO: make getters and setters for validator and transformer
+        if callable(validator):
+            self._validator = validator 
+        elif validator is not None:
+            raise ValueError("Provided 'validator' arg is not callable.")
+        if callable(transformer): 
+            self._transformer = transformer
+        elif transformer is not None:
+            raise ValueError("Provided 'transformer' arg is not callable.")
+    
+    def __repr__(self):
+        return f"{self.Name}:{self._object_address}"
+    
+    def __str__(self):
+        """string representation of the object as Name:address"""
+        return self.__repr__()
+
+    def __hash__(self):
+        return hash(self.__repr__())
+    
+    def __eq__(self, other):
+        return self._object_address == other._object_address
+
+    @property
+    def Name(self):
+        return self._name
+    
+    @property
+    def is_dynamic(self):
+        return callable(self._object_address)
+    
+    def determine_full_address(self, building_template):
+        """Determine the full mutation path for the action in a given building template
+
+        Args:
+            building_template: the building template to find the path in 
+        """
+
+        return (
+            self._object_address(building_template)
+            if self.is_dynamic
+            else self._object_address
+        )
+
+    def determine_parameter_name(self, building_template):
+        """Determine the parameter name to mutate for the action in a given building template
+
+        Args:
+            building_template: the building template to find the path in 
+        """
+        path = self.determine_full_address(building_template)
+        return path[-1]
+
+    def determine_object_address(self, building_template):
+        """Determine the path to the object to mutate for the action in a given building template
+
+        Args:
+            building_template: the building template to find the path in 
+        """
+
+        path = self.determine_full_address(building_template)
+        path = path.copy()
+        path.pop()
+        return path
+
+
+    def lookup_original_value(self, building_template):
+        """Find the current value of the target parameter in a given building template
+
+        Args:
+            building_template: the building template to find the parameter value in
+        """
+        return get_path(
+            root=building_template,
+            address=self.determine_full_address(building_template),
+        )
+
+    def lookup_original_object(self, building_template):
+        """Find the object to mutate in a given building template
+
+        Args:
+            building_template: the building template to find the object in
+        """
+        return get_path(
+            root=building_template,
+            address=self.determine_object_address(building_template)
+        )
+    
+    def compute_new_value(self, building_template, proposed_transformer_value, *args, **kwargs):
+        """Return a proposed new value for the target parameter in a building template
+
+        Args:
+            building_template: the building template to validate a change in
+            proposed_transformer_value: the input to the transformer which generates a new value
+        """
+        original_value = self.lookup_original_value(building_template)
+        new_value = self._transformer(original_value, proposed_transformer_value, *args, **kwargs) if hasattr(self, "_transformer") else proposed_transformer_value
+        return new_value
+
+    def _validate(self, building_template, new_value):
+        """Validate a proposed change to a building template and return the new value
+
+        Args:
+            building_template: the building template to validate a change in
+            new_value: the new value for the target parameter
+        """
+
+        original_value = self.lookup_original_value(building_template)
+        return self._validator(
+                original_value=original_value,
+                new_value=new_value,
+                root=building_template,
+            ) if hasattr(self, "_validator") else True
+
+    def mutate(self, building_template, proposed_transformer_value, *args, **kwargs):
+        new_value = self.compute_new_value(building_template, proposed_transformer_value, *args, **kwargs)
+        validated = self._validate(building_template, new_value)
+        if validated:
+            address = self.determine_full_address(building_template)
+            set_path(
+                root=building_template,
+                address=address,
+                value=new_value
+            )
+
+
+class MeasureProperty:
+    """Class for controlling multiple actions with a single property value"""
+
+    def __init__(self, Name, AttrName, Description, Default, transformer=None, validator=None, actions=None):
+        assert isinstance(Name, str)
+        self._name = Name 
+        assert isinstance(AttrName, str) and AttrName.isidentifier()
+        self._attr_name = AttrName
+        self._description = Description 
+        self._default = Default
+        self._transformer = transformer
+        self._validator = validator
+
+        if isinstance(actions, MeasureAction):
+            actions = [actions] 
+        self._actions = set()
+        for action in actions or []:
+            self.add_action(action)
+
+        self._value = Default
+    
+    @property
+    def Name(self):
+        return self._name
+
+    @property
+    def AttrName(self):
+        return self._attr_name
+
+    @property
+    def Description(self):
+        return self._description
+
+    @property
+    def Default(self):
+        return self._default
+    
+    @Default.setter
+    def Default(self, value):
+        self._default = value
+        self.Value = value
+    
+    @property
+    def Value(self):
+        return self._value
+    
+    @Value.setter
+    def Value(self, value):
+        # In case we want to do some sort of type checking later
+        self._value = value
+    
+    @property
+    def Validator(self):
+        return self._validator
+
+    @Validator.setter
+    def Validator(self, validator):
+        # TODO: Validate that the validator has the correct shape:
+        # lambda root, original_value, new_value: boolean
+        assert callable(validator), "The provided validator is not callable"
+        self._validator = validator
+        for action in self._actions:
+            action._validator = validator
+
+    @property
+    def Transformer(self):
+        return self._transformer
+
+    @Transformer.setter
+    def Transformer(self, transformer):
+        # TODO: Validate that the transformer has the correct shape:
+        # lambda original_value, proposed_transformer_value, *args, **kwargs: boolean
+        assert callable(transformer), "The provided validator is not callable"
+        self._transformer = transformer
+        for action in self._actions:
+            action._transformer = transformer
+
+
+    def add_action(self, action):
+        """Add an action which will be controlled by this property
+
+        Args:
+            action (MeasureAction): the action to add
+        """
+        assert isinstance(action, MeasureAction)
+        if self.Validator and not hasattr(action, "_validator"):
+            action._validator = self.Validator
+        if self.Transformer and not hasattr(action, "_transformer"):
+            print(f"adding a transformer to a an action {action}")
+            action._transformer = self.Transformer
+        self._actions.add(action)
+    
+    def lookup_objects_to_mutate(self, building_template):
+        """Lookup all objects which will be mutated by this property
+
+        Args:
+            building_template: the template to identify all mutation targets in
+        """
+        objects_to_mutate = {} # store the objects to mutate and the path to find it at
+        for action in self._actions:
+            object_to_mutate = action.lookup_original_object(building_template)
+            object_address = action.determine_object_address(building_template)
+            full_path = action.determine_full_address(building_template)
+            if object_to_mutate not in objects_to_mutate:
+                objects_to_mutate[object_to_mutate] = []
+            objects_to_mutate[object_to_mutate].append({"path": full_path, "object_address": object_address})
+        return objects_to_mutate
+    
+    def mutate(self, building_template):
+        for action in self._actions:
+            action.mutate(building_template=building_template, proposed_transformer_value=self.Value)
+    
+    def __repr__(self):
+        """Return a representation of self."""
+        return ":".join([str(self.Name), str(self.AttrName)])
+
+    def __str__(self):
+        """string representation of the object as Name:AttrName"""
+        return self.__repr__()
+
+    def __hash__(self):
+        # Hash using name and attr name
+        return hash(self.__repr__()) 
+
+    def __eq__(self, other):
+        # If two properties have the same name and will use the same attribute, they should be considered equal
+        return self.__repr__() == other.__repr__()
+    
+
+class Measure(object):
     """Main class for the definition of measures.
 
     Args:
-        name (str): The name of the measure.
-        description (str): A description of the measure.
+        Name (str): The name of the measure.
+        Description (str): A description of the measure.
+        Properties (list<MeasureProperty>): Initial properties that are part of the measure
     """
 
-    name = ""
-    description = ""
+    # TODO: Add methods for adding measures together, extending with more properties, etc
+    # TODO: abstract inheritance classes into presets objects
+    __slots__ = (
+        "_name",
+        "_description",
+        "_properties",
+    )
 
-    def __init__(self):
-        self.change_loggers = {}
-        self._props = set()
-        self._actions = set()
+    def __init__(self, Name="Measure", Description="Upgrade Templates", Properties=[]):
+        # TODO: Get multi-class and nested inheritance working
+        super().__setattr__("_properties", set())
 
-    # TODO:
-    # def __add__(self,other): warn if property or method names shared
+        self.Name = Name or self._name
+        self.Description = Description or self._description
 
-    def apply_measure_to_whole_library(self, umi_template_library, *args):
-        """Apply this measure to all building templates in the library."""
-        for bt in umi_template_library.BuildingTemplates:
-            self.apply_measure_to_template(bt, *args)
+        if isinstance(Properties, MeasureProperty):
+            Properties = [Properties]
 
-    def apply_measure_to_template(self, building_template, *args):
-        """Apply this measure to a specific building template.
+        for prop in Properties or []:
+            self.add_property(prop)
+    
+    @property
+    def Name(self):
+        """Get or set the Measure's name"""
+        return self._name
+    
+    @Name.setter
+    def Name(self, name):
+        """Get or set the Measure's name"""
+        self._name = name
 
-        Args:
-            building_template (BuildingTemplate): The building template object.
-        """
-        for _, measure_argument in self.__dict__.items():
-            measure_argument(building_template, *args) if callable(
-                measure_argument
-            ) else None
-            # log.info(f"applied '{measure_argument}' to {building_template}")
+    @property
+    def Description(self):
+        """Get or set the Measure's description"""
+        return self._description
+    
+    @Description.setter
+    def Description(self, description):
+        """Get or set the Measure's description"""
+        self._description = description
 
-    def report_template_changelog(self, building_template):
-        """Return the a dict of changes that will occur if the measure is applied to a template
-
-        Args:
-            building_template (BuildingTemplate): The building template object.
-        """
-        change_log = {}
-        for name, get_changelog in self.change_loggers.items():
-            change = get_changelog(building_template)
-            if change["original_value"] != change["new_value"]:
-                change_log[name] = get_changelog(building_template)
-        return change_log
-
-    def report_library_changelog(self, umi_template_library):
-        """Return the a dict of changes that will occur if the measure is applied to the
-        whole library, stored by template
-
-        Args:
-            umi_template_library (UmiTemplateLibrary): The library to mutate
-        """
-        change_logs = {}
-        for bt in umi_template_library.BuildingTemplates:
-            change_log = self.report_template_changelog(bt)
-            if len(change_log.keys()) > 0:
-                change_logs[bt.Name] = change_log
-        return change_logs
-
-    def add_modifier(
-        self,
-        modifier_name=None,
-        modifier_prop=None,
-        default=None,
-        object_address=None,
-        validator=None,
-    ):
-        """Add an action to the measure which will modify a template parameter with a new
-        property value stored in the measure
-
-        Args:
-            modifier_name (String): A name for the action
-            modifier_prop (String): A name for the measure prop to reference for the value
-            default (any | None): Default value for the measure prop to use
-            object_address (Array<String | int> | (building_template): Array<String | int>): Where to find the target in the template
-            validator ((original_value: any, new_value: any, root: any | None): Boolan)
-        """
-        # TODO: Allow missing object_parameter and non-list-non-callable object_address
-        # TODO: Consider extracting a modifier into its own class
-        log.info(
-            f"Adding {modifier_name} which uses prop {modifier_prop} to the measure {self.name}."
-        )
-
-        # Add the property to the measure's dict
-        if default is not None:
-            setattr(self, modifier_prop, default)
-            if modifier_prop not in self._props:
-                self._props.add(modifier_prop)
-        else:
-            if modifier_prop not in self._props:
-                log.error(
-                    f"Measure {self.name} does not yet have property {modifier_prop} and no default value was provided."
-                )
-                raise AttributeError
-
-        def _address(building_template):
-            return (
-                object_address(building_template)
-                if callable(object_address)
-                else object_address
-            )
-
-        def _parameter(building_template):
-            path = _address(building_template)
-            if type(path) == list:
-                return path[-1]
-            else:
-                return path
-
-        def _original_value(building_template):
-            return get_path(
-                root=building_template,
-                address=_address(building_template),
-            )
-
-        def _new_value(building_template):
-            executes = (
-                validator(
-                    original_value=_original_value(building_template),
-                    new_value=getattr(self, modifier_prop),
-                    root=building_template,
-                )
-                if validator
-                else True
-            )
-            return (
-                getattr(self, modifier_prop)
-                if executes
-                else _original_value(building_template)
-            )
-
-        # Add a setter which dynamically finds the parameter to modify and uses the specified property from the measure
-        setattr(
-            self,
-            modifier_name,
-            lambda building_template: set_path(
-                root=building_template,
-                address=_address(building_template),
-                value=_new_value(building_template),
+    def _get_property_by_name(self, name):
+        """find a MeasureProperty object by Name"""
+        prop = next(
+            iter(
+                    (
+                        x
+                        for x in self._properties
+                        if x.Name == name
+                    )
             ),
+            None,
         )
-        self._actions.add(modifier_name)
+        return prop
 
-        # Store a getter which takes in a template and produces a changelog.
-        self.change_loggers[modifier_name] = lambda building_template: {
-            "address": _address(building_template)[0:-1],
-            "parameter": _parameter(building_template),
-            "original_value": _original_value(building_template),
-            "new_value": _new_value(building_template),
-        }
+    def _get_property_by_attr_name(self, attr_name):
+        """find a MeasureProperty object by AttrName"""
+        prop = next(
+            iter(
+                    (
+                        x
+                        for x in self._properties
+                        if x.AttrName == attr_name
+                    )
+            ),
+            None,
+        )
+        return prop
 
-    @property
-    def props(self):
-        props = {}
-        for prop in self._props:
-            props[prop] = getattr(self, prop)
-        return props
+    def __setitem__(self, name, value):
+        """Change a MeasureProperty's value using the property's Name"""
+        prop = self._get_property_by_name(name)
+        assert isinstance(prop, MeasureProperty), f"Measure:{self.Name} does not have a property named '{name}'"
+        prop.Value = value
 
-    @property
-    def actions(self):
-        actions = {}
-        for action in actions:
-            actions[action] = getattr(self, action)
-        return actions
+    def __getitem__(self, name):
+        """Get a MeasureProperty's value using the property's Name"""
+        prop = self._get_property_by_name(name)
+        assert isinstance(prop, MeasureProperty), f"Measure:{self.Name} does not have a property named '{name}'"
+        return prop.Value
 
-    def __repr__(self):
-        """Return a representation of self."""
-        return self.description
+    
+    def __setattr__(self, attr_name, value):
+        """Change a MeasurProperty's value using the property's AttrName"""
+        prop = self._get_property_by_attr_name(attr_name)
+        if prop is not None:
+            prop.Value = value
+        else:
+            super().__setattr__(attr_name, value)
 
+    def __getattr__(self, attr_name):
+        """Get a MeasureProperty's value using the property AttrName"""
+        prop = self._get_property_by_attr_name(attr_name)
+        if isinstance(prop, MeasureProperty):
+            return prop.Value
+        else:
+            super().__getattr__(attr_name)
+
+    def add_property(self, prop):
+        """Add a property to a measure
+        
+        Args:
+            prop (MeasureProperty): The property to add
+        """
+        assert isinstance(prop, MeasureProperty)
+        assert prop.Name not in [_prop.Name for _prop in self._properties], f"Measure {self} already has a property with the Name {prop.Name}"
+        assert prop.AttrName not in [_prop.AttrName for _prop in self._properties], f"Measure {self} already has a property with the AttrName {prop.AttrName}"
+        self._properties.add(prop)
+    
+    def lookup_objects_to_mutate(self, building_template):
+        """Returns a dict of objects which will be mutated by this measure, 
+        with objects as keys and the path data about the mutations as values.
+        Useful for disentanglement before mutation
+
+        Args:
+            building_template: the building template to determine mutations in
+        """
+        measure_objects_to_mutate = {}
+        for prop in self._properties:
+            prop_objects_to_mutate = prop.lookup_objects_to_mutate(building_template)
+            for object_to_mutate, addresses in prop_objects_to_mutate.items():
+                if object_to_mutate not in measure_objects_to_mutate:
+                    measure_objects_to_mutate[object_to_mutate] = []
+                measure_objects_to_mutate[object_to_mutate].extend(addresses)
+        return measure_objects_to_mutate
+
+    def mutate(self, target, disentangle=True, *args, **kwargs):
+        """Mutate a template or a whole library 
+        
+        Args:
+            target (BuildingTemplate | UmiTemplateLibrary): The template or library to upgrade
+            disentangle (boolean): If true, the tree of each upgraded object will be duplicated and replaced before mutation
+        """
+        if isinstance(target, BuildingTemplate):
+            self.mutate_template(target, disentangle=disentangle, *args, **kwargs)
+        elif isinstance(target, UmiTemplateLibrary):
+            self.mutate_library(target, disentangle=disentangle, *args, **kwargs)
+
+    def mutate_template(self, building_template, disentangle=True, *args, **kwargs):
+        """Mutate a template 
+        
+        Args:
+            target (BuildingTemplate): The template to upgrade
+        """
+        assert isinstance(building_template, BuildingTemplate), "'building_template' argument must be a BuildingTemplate"
+        if disentangle:
+            # Every object which gets mutated is given an entirely new tree to separate it 
+            # from other templates which may have used the objects or even other objects 
+            # within the same template which may use it
+            objects_to_mutate = self.lookup_objects_to_mutate(building_template)
+            for metadatas in objects_to_mutate.values():
+                for metadata in metadatas:
+                    object_address = metadata["object_address"]
+                    for i in range(1, len(object_address)+1):
+                        address = object_address[0:i]
+                        original_object = get_path(root=building_template, address=address)
+                        new_object = original_object.duplicate() if hasattr(original_object, "duplicate") else original_object.copy()
+                        set_path(root=building_template, address=address, value=new_object)
+
+        for prop in self._properties:
+            prop.mutate(building_template, *args, **kwargs)
+    
+    def mutate_library(self, library, disentangle=True, *args, **kwargs):
+        """Mutate a library
+
+        Args:
+            target (UmiTemplateLibrary): The library to upgrade
+        """
+        assert isinstance(library, UmiTemplateLibrary), "'library' argument must be an UmiTemplateLibrary"
+        for bt in library.BuildingTemplates:
+            self.mutate(bt, disentangle=disentangle, *args, **kwargs)
+    
+    # TODO: write changelog functions
 
 class SetMechanicalVentilation(Measure):
     """Set the Mechanical Ventilation."""
 
-    name = "SetMechanicalVentilation"
-    description = ""
+    _name="Set Mechanical Ventilation", 
+    _description="Change mechanical ventilation rates and schedules", 
 
-    def __init__(self, ventilation_ach=3.5, ventilation_schedule=None):
+    def __init__(self, VentilationACH=3.5, VentilationSchedule=None, **kwargs):
         """Initialize measure with parameters."""
-        super(SetMechanicalVentilation, self).__init__()
-
-        self.add_modifier(
-            modifier_name="SetCoreVentilationAch",
-            modifier_prop="ventilation_ach",
-            default=ventilation_ach,
-            object_address=["Core", "Ventilation", "ScheduledVentilationAch"],
+        super(SetMechanicalVentilation, self).__init__(
+            **kwargs,
         )
 
-        self.add_modifier(
-            modifier_name="SetPerimeterVentilationAch",
-            modifier_prop="ventilation_ach",
+        # Configure Ventilation ACH Property and actions
+        ventilation_ach_property = MeasureProperty(
+            Name="Ventilation ACH",
+            AttrName="ventilation_ach",
+            Description="Set Ventilation ACH",
+            Default=VentilationACH,
+        )
+        ventilation_ach_property.add_action(MeasureAction(
+            Name="Set Perimeter Ventilation ACH",
             object_address=["Perimeter", "Ventilation", "ScheduledVentilationAch"],
+        ))
+        ventilation_ach_property.add_action(MeasureAction(
+            Name="Set Core Ventilation ACH",
+            object_address=["Core", "Ventilation", "ScheduledVentilationAch"],
+        ))
+
+        # Configure Ventilation boolean actions
+        ventilation_boolean_property = MeasureProperty(
+            Name="Is Ventilation",
+            AttrName="is_ventilation_on",
+            Description="Automatically turn on scheduled ventilation",
+            Default=True,
         )
-
-        if ventilation_schedule is not None:
-            self.add_modifier(
-                modifier_name="SetCoreVentilationSched",
-                modifier_prop="ventilation_schedule",
-                default=ventilation_schedule,
+        ventilation_boolean_property.add_action(MeasureAction(
+            Name="Set Perimeter Ventilation Toggle",
+            object_address=["Perimeter", "Ventilation", "IsScheduledVentilationOn"],
+        ))
+        ventilation_boolean_property.add_action(MeasureAction(
+            Name="Set Core Ventilation ACH",
+            object_address=["Core", "Ventilation", "IsScheduledVentilationOn"],
+        ))
+        
+        # Configure schedule actions
+        if VentilationSchedule:
+            ventilation_schedule_property = MeasureProperty(
+                Name="Ventilation Schedule",
+                AttrName="ventilation_schedule",
+                Description="Set Ventilation Schedule",
+                Default=VentilationSchedule
+            )
+            ventilation_schedule_property.add_action(MeasureAction(
+                Name="Set Perimeter Ventilation Schedule",
+                object_address=["Perimeter", "Ventilation", "ScheduledVentilationSchedule"],
+            ))
+            ventilation_schedule_property.add_action(MeasureAction(
+                Name="Set Core Ventilation Schedule",
                 object_address=["Core", "Ventilation", "ScheduledVentilationSchedule"],
-            )
-            self.add_modifier(
-                modifier_name="SetPerimeterVentilationSched",
-                modifier_prop="ventilation_schedule",
-                object_address=["Perimeter", "Ventilation", "ScheduledVentilationAch"],
-            )
+            ))
 
-        if ventilation_ach > 0:
-            self.add_modifier(
-                modifier_name="SetCoreVentilationStatus",
-                modifier_prop="ventilation_status",
-                default=True,
-                object_address=["Core", "Ventilation", "IsScheduledVentilationOn"],
-            )
-            self.add_modifier(
-                modifier_name="SetPerimeterVentilationStatus",
-                modifier_prop="ventilation_status",
-                object_address=["Perimeter", "Ventilation", "IsScheduledVentilationOn"],
-            )
+        # Add properties to measure
+        self.add_property(ventilation_ach_property)
+        self.add_property(ventilation_boolean_property)
+        if ventilation_schedule_property:
+            self.add_property(ventilation_schedule_property)
 
 
 class SetCOP(Measure):
     """Set the COPs."""
 
-    name = "SetCOP"
-    description = ""
+    _name="Set HVAC CoP", 
+    _description="Set heating and cooling coefficients of performance", 
 
-    def __init__(self, cooling_cop=3.5, heating_cop=1):
+    def __init__(self, CoolingCoP=3.5, HeatingCoP=1, **kwargs):
         """Initialize measure with parameters."""
-        super(SetCOP, self).__init__()
+        super(SetCOP, self).__init__(
+            **kwargs
+        )
 
-        self.add_modifier(
-            modifier_name="SetCoreCoolingCop",
-            modifier_prop="cooling_cop",
-            default=cooling_cop,
-            object_address=["Core", "Conditioning", "CoolingCoeffOfPerf"],
+        # Configure Heating Property and Actions
+        heating_property = MeasureProperty(
+            Name="Heating CoP",
+            AttrName="HeatingCoP",
+            Description="Set Heating Coefficient of Performance",
+            Default=HeatingCoP,
         )
-        self.add_modifier(
-            modifier_name="SetPerimeterCoolingCop",
-            modifier_prop="cooling_cop",
-            object_address=["Perimeter", "Conditioning", "CoolingCoeffOfPerf"],
-        )
-        self.add_modifier(
-            modifier_name="SetCoreHeatingCop",
-            modifier_prop="heating_cop",
-            default=heating_cop,
-            object_address=["Core", "Conditioning", "HeatingCoeffOfPerf"],
-        )
-        self.add_modifier(
-            modifier_name="SetPerimeterHeatingCop",
-            modifier_prop="heating_cop",
+        heating_property.add_action(MeasureAction(
+            Name="Set Perimeter Heating CoP",
             object_address=["Perimeter", "Conditioning", "HeatingCoeffOfPerf"],
+        ))
+        heating_property.add_action(MeasureAction(
+            Name="Set Core Core Heating CoP",
+            object_address=["Core", "Conditioning", "HeatingCoeffOfPerf"],
+        ))
+
+        # Configure Cooling Property and Actions
+        cooling_property = MeasureProperty(
+            Name="Cooling CoP",
+            AttrName="CoolingCoP",
+            Description="Set Cooling Coefficient of Performance",
+            Default=CoolingCoP,
         )
+        cooling_property.add_action(MeasureAction(
+            Name="Set Perimeter Cooling CoP",
+            object_address=["Perimeter", "Conditioning", "CoolingCoeffOfPerf"],
+        ))
+        cooling_property.add_action(MeasureAction(
+            Name="Set Core Core Cooling CoP",
+            object_address=["Core", "Conditioning", "CoolingCoeffOfPerf"],
+        ))
+
+        # Add properties to measure
+        self.add_property(heating_property)
+        self.add_property(cooling_property)
+        
 
 
-class EnergyStarUpgrade(Measure):
-    """The EnergyStarUpgrade changes the equipment power density to."""
+class SetElectricLoadsEfficiency(Measure):
+    """The EnergyStarUpgrade changes the equipment power density too."""
 
-    name = "EnergyStarUpgrade"
-    description = "EnergyStar for tenant spaces of 0.75 W/sf ~= 8.07 W/m2"
+    _name="Electric Loads Efficiency",
+    _description="Change equipment and lighting loads efficiency",
 
-    def __init__(self, lighting_power_density=8.07, equipment_power_density=8.07):
+    def __init__(self, LightingPowerDensity=8.07, EquipmentPowerDensity=8.07, **kwargs):
         """Initialize measure with parameters."""
-        super(EnergyStarUpgrade, self).__init__()
-
-        self.add_modifier(
-            modifier_name="SetCoreLightingPowerDensity",
-            modifier_prop="lighting_power_density",
-            default=lighting_power_density,
-            object_address=["Core", "Loads", "LightingPowerDensity"],
+        super(SetElectricLoadsEfficiency, self).__init__(
+            **kwargs
         )
-        self.add_modifier(
-            modifier_name="SetPerimeterLightingPowerDensity",
-            modifier_prop="lighting_power_density",
-            object_address=["Perimeter", "Loads", "LightingPowerDensity"],
+        
+        # Configure Equipment Properties and Actions
+        equipment_property = MeasureProperty(
+            Name="Equipment Power Density", 
+            AttrName="EquipmentPowerDensity", 
+            Description="Change Equipment Power Density", 
+            Default=EquipmentPowerDensity, 
         )
-        self.add_modifier(
-            modifier_name="SetCoreEquipmentPowerDensity",
-            modifier_prop="equipment_power_density",
-            default=equipment_power_density,
-            object_address=["Core", "Loads", "EquipmentPowerDensity"],
+        equipment_property.add_action(MeasureAction(
+            Name="Change Perimeter Equipment Power Density", 
+            object_address=["Perimeter", "Loads", "EquipmentPowerDensity"]
+        ))
+        equipment_property.add_action(MeasureAction(
+            Name="Change Core Equipment Power Density", 
+            object_address=["Core", "Loads", "EquipmentPowerDensity"]
+        ))
+
+        # Configure Lighting Properties and Actions
+        lighting_property = MeasureProperty(
+            Name="Lighting Power Density", 
+            AttrName="LightingPowerDensity", 
+            Description="Change Lighting Power Density", 
+            Default=LightingPowerDensity,
         )
-        self.add_modifier(
-            modifier_name="SetPerimeterEquipmentPowerDensity",
-            modifier_prop="equipment_power_density",
-            object_address=["Perimeter", "Loads", "EquipmentPowerDensity"],
-        )
+        lighting_property.add_action(MeasureAction(
+            Name="Change Perimeter Lighting Power Density", 
+            object_address=["Perimeter", "Loads", "LightingPowerDensity"]
+        ))
+        lighting_property.add_action(MeasureAction(
+            Name="Change Core Lighting Power Density", 
+            object_address=["Core", "Loads", "LightingPowerDensity"]
+        ))
+
+        # Add properties to measure
+        self.add_property(equipment_property)
+        self.add_property(lighting_property)
 
 
-class SetFacadeConstructionThermalResistanceToEnergyStar(Measure):
-    """Facade upgrade.
+class SetFacadeInsulationThermalResistance(Measure):
 
-    Changes the r-value of the insulation layer of the facade construction to R5.78.
-    """
+    _name = "Facade Upgrade (Insulation Only)"
+    _description = "Upgrade roof and facade insulation by specifying R-Values for the Insulation Layers."
 
-    name = "SetFacadeConstructionThermalResistanceToEnergyStar"
-    description = (
-        "This measure changes the r-value of the insulation layer of the "
-        "facade construction to R5.78."
-    )
-    rsi_value_facade = 3.08
-    rsi_value_roof = 5.02
-
-    def __init__(self, rsi_value_facade=None, rsi_value_roof=None):
-        """Initialize measure with parameters.
-
-        Notes:
-            Changes the thickness of the insulation layer to match the selected
-            rsi_value.
-
-        Args:
-            rsi_value_facade (float): The new rsi value for external walls.
-        """
-        super(SetFacadeConstructionThermalResistanceToEnergyStar, self).__init__()
-
-        def get_insulation_layer_path(building_template, structural_part):
-            constructions = building_template.Perimeter.Constructions
-            insulation_layer_index = getattr(
-                constructions, structural_part
-            ).infer_insulation_layer()
-            return [
-                "Perimeter",
-                "Constructions",
-                structural_part,
-                "Layers",
-                insulation_layer_index,
-                "r_value",
-            ]
-
-        # TODO: reproduce original warning in _set_insulation_layer_resistance
-        self.add_modifier(
-            modifier_name="AlterFacade",
-            modifier_prop="rsi_value_facade",
-            default=rsi_value_facade if rsi_value_facade else self.rsi_value_facade,
-            object_address=lambda building_template: get_insulation_layer_path(
-                building_template, "Facade"
-            ),
+    def __init__(self, RoofRValue=5.02, FacadeRValue=3.08, **kwargs):
+        super(SetFacadeInsulationThermalResistance, self).__init__(
+            **kwargs
         )
 
-        self.add_modifier(
-            modifier_name="AlterRoof",
-            modifier_prop="rsi_value_roof",
-            default=rsi_value_roof if rsi_value_roof else self.rsi_value_roof,
-            object_address=lambda building_template: get_insulation_layer_path(
-                building_template, "Roof"
-            ),
+        def make_get_insulation_layer_path(structural_part):
+            def get_insulation_layer_path(building_template):
+                constructions = building_template.Perimeter.Constructions
+                insulation_layer_index = getattr(
+                    constructions, structural_part
+                ).infer_insulation_layer()
+                return [
+                    "Perimeter",
+                    "Constructions",
+                    structural_part,
+                    "Layers",
+                    insulation_layer_index,
+                    "r_value",
+                ]
+            return get_insulation_layer_path
+
+        get_facade_insulation_layer_path = make_get_insulation_layer_path("Facade")
+        get_roof_insulation_layer_path = make_get_insulation_layer_path("Roof")
+
+        facade_insulation_property = MeasureProperty(
+            Name="Facade Insulation R-Value",
+            AttrName="FacadeRValue",
+            Description="Set facade insulation layer R-Value",
+            Default=FacadeRValue,
+        )
+        facade_insulation_property.add_action(MeasureAction(
+            Name="Change Facade Insualtion Layer R-Value",
+            object_address=get_facade_insulation_layer_path
+        ))
+        self.add_property(facade_insulation_property)
+
+        roof_insulation_property = MeasureProperty(
+            Name="Roof Insulation R-Value",
+            AttrName="RoofRValue",
+            Description="Set roof insulation layer R-Value",
+            Default=RoofRValue,
+        )
+        roof_insulation_property.add_action(MeasureAction(
+            Name="Change Roof Insualtion Layer R-Value",
+            object_address=get_roof_insulation_layer_path
+        ))
+        self.add_property(roof_insulation_property)
+
+    @classmethod
+    def Best(cls):
+        return cls(
+            FacadeRValue = 1 / 0.13, 
+            RoofRValue = 1 / 0.11, 
+            Name="Facade Upgrade Best",
+            Description="Set R-Value of roof and facade using values from climaplusbeta.com",
         )
 
+    @classmethod
+    def Mid(cls):
+        return cls(
+            FacadeRValue = 1 / 0.34, 
+            RoofRValue = 1 / 0.33, 
+            Name="Facade Upgrade Mid",
+            Description="Set R-Value of roof and facade using values from climaplusbeta.com",
+        )
 
-class FacadeUpgradeBest(SetFacadeConstructionThermalResistanceToEnergyStar):
-    """A facade upgrade using best in class thermal insulation properties."""
+    @classmethod
+    def Regular(cls):
+        return cls(
+            FacadeRValue = 1 / 1.66, 
+            RoofRValue = 1 / 2.37, 
+            Name="Facade Upgrade Regular",
+            Description="Set R-Value of roof and facade using values from climaplusbeta.com",
+        )
 
-    name = "FacadeUpgradeBest"
-    description = "rsi value from climaplusbeta.com"
-    rsi_value_facade = 1 / 0.13
-    rsi_value_roof = 1 / 0.11
+    @classmethod
+    def Low(cls):
+        return cls(
+            FacadeRValue = 1 / 3.5, 
+            RoofRValue = 1 / 4.5, 
+            Name="Facade Upgrade Regular",
+            Description="Set R-Value of roof and facade using values from climaplusbeta.com",
+        )
+
+class SetFacadeThermalResistance(Measure):
+
+    _name = "Facade Upgrade"
+    _description = "Upgrade roof and facade insulation by specifying R-Values for entire assemblies."
+
+    def __init__(self, RoofRValue, FacadeRValue, **kwargs):
 
 
-class FacadeUpgradeMid(SetFacadeConstructionThermalResistanceToEnergyStar):
-    """A facade upgrade using median thermal insulation properties."""
+        super(SetFacadeThermalResistance, self).__init__(
+            **kwargs
+        )
+        roof_property = MeasureProperty(
+            Name="Roof R-Value",
+            AttrName="RoofRValue",
+            Description="R-value for entire roof assembly",
+            Default=RoofRValue,
+        )
+        roof_property.add_action(MeasureAction(
+            Name="Change Roof R-Value",
+            object_address=["Perimeter", "Constructions", "Roof", "r_value"]
+        ))
+        facade_property = MeasureProperty(
+            Name="Facade R-Value",
+            AttrName="FacadeRValue",
+            Description="R-value for entire facade assembly",
+            Default=FacadeRValue,
+        )
+        facade_property.add_action(MeasureAction(
+            Name="Change Facade R-Value",
+            object_address=["Perimeter", "Constructions", "Facade", "r_value"]
+        ))
 
-    name = "FacadeUpgradeMid"
-    description = "rsi value from climaplusbeta.com"
-    rsi_value_facade = 1 / 0.34
-    rsi_value_roof = 1 / 0.33
+        self.add_property(roof_property)
+        self.add_property(facade_property)
 
+    @classmethod
+    def Best(cls):
+        return cls(
+            FacadeRValue = 15, 
+            RoofRValue = 10, 
+            Name="Facade Upgrade Best",
+            Description="Set R-Value of roof and facade using values from climaplusbeta.com",
+        )
 
-class FacadeUpgradeRegular(SetFacadeConstructionThermalResistanceToEnergyStar):
-    """A facade upgrade using to-code thermal insulation properties."""
+    @classmethod
+    def Mid(cls):
+        return cls(
+            FacadeRValue = 10, 
+            RoofRValue = 10, 
+            Name="Facade Upgrade Mid",
+            Description="Set R-Value of roof and facade using values from climaplusbeta.com",
+        )
 
-    name = "FacadeUpgradeRegular"
-    description = "rsi value from climaplusbeta.com"
-    rsi_value_facade = 1 / 1.66
-    rsi_value_roof = 1 / 2.37
+    @classmethod
+    def Regular(cls):
+        return cls(
+            FacadeRValue = 2, 
+            RoofRValue = 2, 
+            Name="Facade Upgrade Regular",
+            Description="Set R-Value of roof and facade using values from climaplusbeta.com",
+        )
 
-
-class FacadeUpgradeLow(SetFacadeConstructionThermalResistanceToEnergyStar):
-    """A facade upgrade using affordable thermal insulation properties."""
-
-    name = "FacadeUpgradeLow"
-    description = "rsi value from climaplusbeta.com"
-    rsi_value_facade = 1 / 3.5
-    rsi_value_roof = 1 / 4.5
+    @classmethod
+    def Low(cls):
+        return cls(
+            FacadeRValue = 1, 
+            RoofRValue = 1, 
+            Name="Facade Upgrade Regular",
+            Description="Set R-Value of roof and facade using values from climaplusbeta.com",
+        )
 
 
 class SetInfiltration(Measure):
-    name = "SetInfiltration"
-    description = "This measure sets the infiltration ACH of the perimeter zone."
-    infiltration_ach = 0.6
 
-    def __init__(self, infiltration_ach=None):
-        super().__init__()
-        self.add_modifier(
-            modifier_name="SetInfiltration",
-            modifier_prop="infiltration_ach",
-            default=infiltration_ach if infiltration_ach else self.infiltration_ach,
+    _name="Set Infiltration",
+    _description="This measure sets the infiltration ACH of the perimeter zone.",
+
+    def __init__(self, Infiltration=0.6, **kwargs):
+        infiltration_action = MeasureAction(
+            Name="Set Infiltration ACH",
             object_address=["Perimeter", "Ventilation", "Infiltration"],
+            **kwargs,
+        )
+        infiltration_property=MeasureProperty(
+            Name="Infiltration",
+            AttrName="Infiltration",
+            Description="Set Infiltration ACH",
+            Default=Infiltration,
+            actions=infiltration_action,
         )
 
+        super().__init__(
+            Properties=infiltration_property
+        )
 
-class InfiltrationRegular(SetInfiltration):
-    infiltration_ach = 0.6
+    @classmethod
+    def Regular(cls):
+        return cls(
+            Infiltration = 0.6
+        )
 
+    @classmethod
+    def Medium(cls):
+        return cls(
+            Infiltration = 0.3
+        )
 
-class InfiltrationMedium(SetInfiltration):
-    infiltration_ach = 0.3
-
-
-class InfiltrationTight(SetInfiltration):
-    infiltration_ach = 0.1
+    @classmethod
+    def Tight(cls):
+        return cls(
+            Infiltration = 0.1
+        )

--- a/archetypal/template/measures/measure.py
+++ b/archetypal/template/measures/measure.py
@@ -1,0 +1,275 @@
+"""Energy measures modules."""
+import logging
+
+from archetypal.template.materials.material_layer import MaterialLayer
+
+log = logging.getLogger(__name__)
+
+
+class Measure:
+    """Main class for the definition of measures.
+
+    Args:
+        name (str): The name of the measure.
+        description (str): A description of the measure.
+    """
+
+    name = ""
+    description = ""
+
+    def __init__(self):
+        pass
+
+    def apply_measure_to_whole_library(self, umi_template_library, *args):
+        """Apply this measure to all building templates in the library."""
+        for bt in umi_template_library.BuildingTemplates:
+            self.apply_measure_to_template(bt, *args)
+
+    def apply_measure_to_template(self, building_template, *args):
+        """Apply this measure to a specific building template.
+
+        Args:
+            building_template (BuildingTemplate): The building template object.
+        """
+        for _, measure_argument in self.__dict__.items():
+            measure_argument(building_template, *args) if callable(
+                measure_argument
+            ) else None
+            log.info(f"applied '{measure_argument}' to {building_template}")
+
+    def __repr__(self):
+        """Return a representation of self."""
+        return self.description
+
+
+class SetMechanicalVentilation(Measure):
+    """Set the Mechanical Ventilation."""
+
+    name = "SetMechanicalVentilation"
+    description = ""
+
+    def __init__(self, ach=3.5, ventilation_schedule=None):
+        """Initialize measure with parameters."""
+        super(SetMechanicalVentilation, self).__init__()
+
+        self.SetCoreVentilationAch = lambda building_template: setattr(
+            building_template.Core.Ventilation, "ScheduledVentilationAch", ach
+        )
+        self.SetPerimVentilationAch = lambda building_template: setattr(
+            building_template.Perimeter.Ventilation, "ScheduledVentilationAch", ach
+        )
+        if ventilation_schedule is not None:
+            self.SetCoreVentilation = lambda building_template: setattr(
+                building_template.Core.Ventilation,
+                "ScheduledVentilationSchedule",
+                ventilation_schedule,
+            )
+            self.SetPerimVentilation = lambda building_template: setattr(
+                building_template.Perimeter.Ventilation,
+                "ScheduledVentilationSchedule",
+                ventilation_schedule,
+            )
+        if ach > 0:
+            self.SetCoreScheduledVentilationOn = lambda building_template: setattr(
+                building_template.Perimeter.Ventilation,
+                "IsScheduledVentilationOn",
+                True,
+            )
+            self.SetPerimeterScheduledVentilationOn = lambda building_template: setattr(
+                building_template.Perimeter.Ventilation,
+                "IsScheduledVentilationOn",
+                True,
+            )
+
+
+class SetCOP(Measure):
+    """Set the COPs."""
+
+    name = "SetCOP"
+    description = ""
+
+    def __init__(self, cooling_cop=3.5, heating_cop=1):
+        """Initialize measure with parameters."""
+        super(SetCOP, self).__init__()
+
+        self.SetCoreCoolingCOP = lambda building_template: setattr(
+            building_template.Core.Conditioning, "CoolingCoeffOfPerf", cooling_cop
+        )
+        self.SetPerimCoolingCOP = lambda building_template: setattr(
+            building_template.Perimeter.Conditioning, "CoolingCoeffOfPerf", cooling_cop
+        )
+        self.SetCoreHeatingCOP = lambda building_template: setattr(
+            building_template.Core.Conditioning, "HeatingCoeffOfPerf", heating_cop
+        )
+        self.SetPerimHeatingCOP = lambda building_template: setattr(
+            building_template.Perimeter.Conditioning, "HeatingCoeffOfPerf", heating_cop
+        )
+
+
+class EnergyStarUpgrade(Measure):
+    """The EnergyStarUpgrade changes the equipment power density to."""
+
+    name = "EnergyStarUpgrade"
+    description = "EnergyStar for tenant spaces of 0.75 W/sf ~= 8.07 W/m2"
+
+    def __init__(self, lighting_power_density=8.07, equipment_power_density=8.07):
+        """Initialize measure with parameters."""
+        super(EnergyStarUpgrade, self).__init__()
+
+        self.SetCoreLightingPowerDensity = lambda building_template: setattr(
+            building_template.Core.Loads, "LightingPowerDensity", lighting_power_density
+        )
+        self.SetPerimLightingPowerDensity = lambda building_template: setattr(
+            building_template.Perimeter.Loads,
+            "LightingPowerDensity",
+            lighting_power_density,
+        )
+        self.SetCoreEquipementPowerDensity = lambda building_template: setattr(
+            building_template.Core.Loads,
+            "EquipmentPowerDensity",
+            equipment_power_density,
+        )
+        self.SetPerimEquipementPowerDensity = lambda building_template: setattr(
+            building_template.Perimeter.Loads,
+            "EquipmentPowerDensity",
+            equipment_power_density,
+        )
+
+
+class SetFacadeConstructionThermalResistanceToEnergyStar(Measure):
+    """Facade upgrade.
+
+    Changes the r-value of the insulation layer of the facade construction to R5.78.
+    """
+
+    name = "SetFacadeConstructionThermalResistanceToEnergyStar"
+    description = (
+        "This measure changes the r-value of the insulation layer of the "
+        "facade construction to R5.78."
+    )
+    rsi_value_facade = 3.08
+    rsi_value_roof = 5.02
+
+    def __init__(self, rsi_value_facade=None, rsi_value_roof=None):
+        """Initialize measure with parameters.
+
+        Notes:
+            Changes the thickness of the insulation layer to match the selected
+            rsi_value.
+
+        Args:
+            rsi_value_facade (float): The new rsi value for external walls.
+        """
+        super(SetFacadeConstructionThermalResistanceToEnergyStar, self).__init__()
+
+        if rsi_value_facade is not None:
+            self.rsi_value_facade = rsi_value_facade
+            self.rsi_value_roof = rsi_value_roof
+
+        self.AlterFacade = (
+            lambda building_template: self._set_insulation_layer_resistance(
+                building_template.Perimeter.Constructions.Facade, self.rsi_value_facade
+            )
+        )
+        self.AlterRoof = (
+            lambda building_template: self._set_insulation_layer_resistance(
+                building_template.Perimeter.Constructions.Roof, self.rsi_value_roof
+            )
+        )
+
+    def _set_insulation_layer_resistance(self, opaque_construction, rsi_value):
+        """Set the insulation later to r_value = 3.08.
+
+        Hint:
+            See `Table 2`_: Minimum Effective Thermal Resistance of Opaque Assemblies.
+
+        .. _Table 2:
+            https://www.nrcan.gc.ca/energy-efficiency/energy-star-canada/
+            about-energy-star-canada/energy-star-announcements/energy-starr-
+            new-homes-standard-version-126/14178
+        """
+        # First, find the insulation layer
+        i = opaque_construction.infer_insulation_layer()
+        layer: MaterialLayer = opaque_construction.Layers[i]
+
+        # Then, change the r_value (which changes the thickness) of that layer only.
+        energy_star_rsi = rsi_value
+        if layer.r_value > energy_star_rsi:
+            log.debug(
+                f"r_value is already higher for material_layer '{layer}' of "
+                f"opaque_construction '{opaque_construction}'"
+            )
+        layer.r_value = energy_star_rsi
+
+
+class FacadeUpgradeBest(SetFacadeConstructionThermalResistanceToEnergyStar):
+    """A facade upgrade using best in class thermal insulation properties."""
+
+    name = "FacadeUpgradeBest"
+    description = "rsi value from climaplusbeta.com"
+    rsi_value_facade = 1 / 0.13
+    rsi_value_roof = 1 / 0.11
+
+
+class FacadeUpgradeMid(SetFacadeConstructionThermalResistanceToEnergyStar):
+    """A facade upgrade using median thermal insulation properties."""
+
+    name = "FacadeUpgradeMid"
+    description = "rsi value from climaplusbeta.com"
+    rsi_value_facade = 1 / 0.34
+    rsi_value_roof = 1 / 0.33
+
+
+class FacadeUpgradeRegular(SetFacadeConstructionThermalResistanceToEnergyStar):
+    """A facade upgrade using to-code thermal insulation properties."""
+
+    name = "FacadeUpgradeRegular"
+    description = "rsi value from climaplusbeta.com"
+    rsi_value_facade = 1 / 1.66
+    rsi_value_roof = 1 / 2.37
+
+
+class FacadeUpgradeLow(SetFacadeConstructionThermalResistanceToEnergyStar):
+    """A facade upgrade using affordable thermal insulation properties."""
+
+    name = "FacadeUpgradeLow"
+    description = "rsi value from climaplusbeta.com"
+    rsi_value_facade = 1 / 3.5
+    rsi_value_roof = 1 / 4.5
+
+
+class SetInfiltration(Measure):
+    name = "SetInfiltration"
+    description = "This measure sets the infiltration ACH of the perimeter zone."
+    infiltration_ach = 0.6
+
+    def __init__(self, infiltration_ach=None):
+        super().__init__()
+        if infiltration_ach is not None:
+            self.infiltration_ach = infiltration_ach
+
+        self.SetInfiltration = lambda building_template: setattr(
+            building_template.Perimeter.Ventilation,
+            "Infiltration",
+            self.infiltration_ach,
+        )
+
+    def _apply(self, building_template):
+        """Only apply to Perimeter zone ventilation.
+
+        Args:
+            building_template (BuildingTemplate): The building template object.
+        """
+        building_template.Perimeter.Ventilation.Infiltration = self.infiltration_ach
+
+
+class InfiltrationRegular(SetInfiltration):
+    infiltration_ach = 0.6
+
+
+class InfiltrationMedium(SetInfiltration):
+    infiltration_ach = 0.3
+
+
+class InfiltrationTight(SetInfiltration):
+    infiltration_ach = 0.1

--- a/archetypal/template/measures/measure.py
+++ b/archetypal/template/measures/measure.py
@@ -559,6 +559,27 @@ class Measure(object):
         """Get or set the Measure's description"""
         self._description = description
 
+    def __iter__(self):
+        for prop in self._properties:
+            yield prop
+
+    def __add__(self, other):
+        # prefer LHS metadata
+        new_measure = Measure(
+            Name=self.Name,
+            Description=self.Description,
+            Properties=[prop for prop in self],
+        )
+        for prop in other:
+            new_measure.add_property(prop)
+
+        return new_measure
+
+    def __iadd__(self, other):
+        for prop in other:
+            self.add_property(prop)
+        return self
+
     def _get_property_by_name(self, name):
         """find a MeasureProperty object by Name"""
         prop = next(

--- a/archetypal/template/measures/measure.py
+++ b/archetypal/template/measures/measure.py
@@ -1118,7 +1118,7 @@ class SetFacadeThermalResistance(Measure):
     _name = "Facade Upgrade"
     _description = "Upgrade roof and facade insulation by specifying R-Values for entire assemblies."
 
-    def __init__(self, RoofRValue, FacadeRValue, **kwargs):
+    def __init__(self, RoofRValue=1/2.37, FacadeRValue=1/1.66, **kwargs):
 
         super(SetFacadeThermalResistance, self).__init__(**kwargs)
         roof_property = MeasureProperty(

--- a/archetypal/template/schedule.py
+++ b/archetypal/template/schedule.py
@@ -17,6 +17,7 @@ from archetypal.utils import log
 
 class UmiSchedule(Schedule, UmiBase):
     """Class that handles Schedules."""
+
     _CREATED_OBJECTS = []
 
     __slots__ = ("_quantity",)

--- a/archetypal/template/umi_base.py
+++ b/archetypal/template/umi_base.py
@@ -410,8 +410,7 @@ class UmiBase(object):
                         (
                             x
                             for x in self._CREATED_OBJECTS
-                            if x == self
-                            and x.Name == self.Name
+                            if x == self and x.Name == self.Name
                         ),
                         key=lambda x: x.unit_number,
                     )
@@ -424,11 +423,7 @@ class UmiBase(object):
             obj = next(
                 iter(
                     sorted(
-                        (
-                            x
-                            for x in self._CREATED_OBJECTS
-                            if x == self
-                        ),
+                        (x for x in self._CREATED_OBJECTS if x == self),
                         key=lambda x: x.unit_number,
                     )
                 ),

--- a/archetypal/template/ventilation.py
+++ b/archetypal/template/ventilation.py
@@ -466,7 +466,6 @@ class VentilationSetting(UmiBase):
               "IsInfiltrationOn": true,
               "IsNatVentOn": false,
               "IsScheduledVentilationOn": false,
-              "VentilationType": 2,
               "NatVentMaxRelHumidity": 80.0,
               "NatVentMaxOutdoorAirTemp": 26.0,
               "NatVentMinOutdoorAirTemp": 20.0,
@@ -516,7 +515,6 @@ class VentilationSetting(UmiBase):
         data_dict["NatVentSchedule"] = self.NatVentSchedule.to_ref()
         data_dict["NatVentZoneTempSetpoint"] = round(self.NatVentZoneTempSetpoint, 3)
         data_dict["ScheduledVentilationAch"] = round(self.ScheduledVentilationAch, 3)
-        data_dict["VentilationType"] = self.VentilationType.value
         data_dict[
             "ScheduledVentilationSchedule"
         ] = self.ScheduledVentilationSchedule.to_ref()

--- a/archetypal/template/ventilation.py
+++ b/archetypal/template/ventilation.py
@@ -62,6 +62,7 @@ class VentilationSetting(UmiBase):
 
     .. image:: ../images/template/zoneinfo-ventilation.png
     """
+
     _CREATED_OBJECTS = []
 
     __slots__ = (
@@ -868,7 +869,9 @@ class VentilationSetting(UmiBase):
             )
         else:
             infiltration_epbunch = None
-            log("No 'ZONEINFILTRATION:DESIGNFLOWRATE' created since IsInfiltrationOn == False.")
+            log(
+                "No 'ZONEINFILTRATION:DESIGNFLOWRATE' created since IsInfiltrationOn == False."
+            )
 
         if self.IsScheduledVentilationOn:
             ventilation_epbunch = idf.newidfobject(
@@ -904,7 +907,9 @@ class VentilationSetting(UmiBase):
             )
         else:
             ventilation_epbunch = None
-            log("No 'ZONEVENTILATION:DESIGNFLOWRATE' created since IsScheduledVentilationOn == False.")
+            log(
+                "No 'ZONEVENTILATION:DESIGNFLOWRATE' created since IsScheduledVentilationOn == False."
+            )
 
         if self.IsNatVentOn:
             natural_epbunch = idf.newidfobject(
@@ -931,7 +936,9 @@ class VentilationSetting(UmiBase):
             )
         else:
             natural_epbunch = None
-            log("No 'ZONEVENTILATION:WINDANDSTACKOPENAREA' created since IsNatVentOn == False.")
+            log(
+                "No 'ZONEVENTILATION:WINDANDSTACKOPENAREA' created since IsNatVentOn == False."
+            )
 
         return infiltration_epbunch, ventilation_epbunch, natural_epbunch
 

--- a/archetypal/template/ventilation.py
+++ b/archetypal/template/ventilation.py
@@ -466,6 +466,7 @@ class VentilationSetting(UmiBase):
               "IsInfiltrationOn": true,
               "IsNatVentOn": false,
               "IsScheduledVentilationOn": false,
+              "VentilationType": 2,
               "NatVentMaxRelHumidity": 80.0,
               "NatVentMaxOutdoorAirTemp": 26.0,
               "NatVentMinOutdoorAirTemp": 20.0,
@@ -515,6 +516,7 @@ class VentilationSetting(UmiBase):
         data_dict["NatVentSchedule"] = self.NatVentSchedule.to_ref()
         data_dict["NatVentZoneTempSetpoint"] = round(self.NatVentZoneTempSetpoint, 3)
         data_dict["ScheduledVentilationAch"] = round(self.ScheduledVentilationAch, 3)
+        data_dict["VentilationType"] = self.VentilationType.value
         data_dict[
             "ScheduledVentilationSchedule"
         ] = self.ScheduledVentilationSchedule.to_ref()

--- a/archetypal/template/window_setting.py
+++ b/archetypal/template/window_setting.py
@@ -36,6 +36,7 @@ class WindowSetting(UmiBase):
 
     .. _eppy : https://eppy.readthedocs.io/en/latest/
     """
+
     _CREATED_OBJECTS = []
 
     __slots__ = (

--- a/archetypal/template/zone_construction_set.py
+++ b/archetypal/template/zone_construction_set.py
@@ -12,6 +12,7 @@ from archetypal.utils import log, reduce, timeit
 
 class ZoneConstructionSet(UmiBase):
     """ZoneConstructionSet class."""
+
     _CREATED_OBJECTS = []
 
     __slots__ = (

--- a/archetypal/template/zonedefinition.py
+++ b/archetypal/template/zonedefinition.py
@@ -25,6 +25,7 @@ class ZoneDefinition(UmiBase):
 
     .. image:: ../images/template/zoneinfo-zone.png
     """
+
     _CREATED_OBJECTS = []
 
     __slots__ = (

--- a/archetypal/umi_template.py
+++ b/archetypal/umi_template.py
@@ -184,6 +184,18 @@ class UmiTemplateLibrary:
             objs.extend(group)
         return objs
 
+    @property
+    def objects_by_id(self):
+        """Get dictionary of objects with their id as a key.
+
+        Note:
+            Includes orphaned objects.
+        """
+        objs_dict = {}
+        for name, group in self:
+            objs_dict.update({obj.id: obj for obj in group})
+        return objs_dict
+
     @classmethod
     def from_idf_files(
         cls,

--- a/archetypal/umi_template.py
+++ b/archetypal/umi_template.py
@@ -846,3 +846,9 @@ def parent_child_traversal(parent):
     for child in parent.children:
         yield parent, child
         yield from parent_child_traversal(child)
+
+
+def traverse(parent):
+    """Iterate over all children of the parent. 
+    """
+    return parent_child_traversal(parent)

--- a/docs/package_modules.rst
+++ b/docs/package_modules.rst
@@ -81,6 +81,30 @@ Classes that support the :ref:`templates_label` classes above.
     constructions.window_construction.WindowType
     constructions.window_construction.ShadingType
 
+UMI Measures
+------------
+
+.. currentmodule:: archetypal.template.measures
+
+.. autosummary::
+    :template: autosummary.rst
+    :nosignatures:
+    :toctree: reference/
+
+    Measure
+
+Available Measures
+..................
+
+.. autosummary::
+    :template: autosummary.rst
+    :nosignatures:
+    :toctree: reference/
+
+    EnergyStarUpgrade
+    SetFacadeConstructionThermalResistanceToEnergyStar
+
+
 Graph Module
 ------------
 

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -104,14 +104,13 @@ class TestMeasure:
             assert bldg.Perimeter.Ventilation.Infiltration == infiltration_ach
 
     @pytest.mark.parametrize(
-        "modifier_name, modifier_prop, default, object_address, object_parameter, getExpectedValue",
+        "modifier_name, modifier_prop, default, object_address, getExpectedValue",
         [
             (
                 "SetPerimeterCoolingSetpoint",
                 "cooling_setpoint",
                 27,
-                ["Perimeter", "Conditioning"],
-                "CoolingSetpoint",
+                ["Perimeter", "Conditioning", "CoolingSetpoint"],
                 # Explicitly tell the test where to find the correct val
                 lambda bt: bt.Perimeter.Conditioning.CoolingSetpoint,
             ),
@@ -119,8 +118,7 @@ class TestMeasure:
                 "SetCoreHeatingSetpoint",
                 "heating_setpoint",
                 20,
-                ["Core", "Conditioning"],
-                "HeatingSetpoint",
+                ["Core", "Conditioning", "HeatingSetpoint"],
                 lambda bt: bt.Core.Conditioning.HeatingSetpoint,
             ),
         ],
@@ -131,7 +129,6 @@ class TestMeasure:
         modifier_prop,
         default,
         object_address,
-        object_parameter,
         umi_library,
         getExpectedValue,
     ):
@@ -151,7 +148,6 @@ class TestMeasure:
                     modifier_prop=modifier_prop,
                     default=default,
                     object_address=object_address,
-                    object_parameter=object_parameter,
                 )
 
         # create the measure
@@ -191,16 +187,14 @@ class TestMeasure:
             modifier_name="SetPerimCoolingCoP",
             modifier_prop="cooling_CoP",
             default=0.01,
-            object_address=["Perimeter", "Conditioning"],
-            object_parameter="CoolingCoeffOfPerf",
+            object_address=["Perimeter", "Conditioning", "CoolingCoeffOfPerf"],
             validator=gtValidator,
         )
         measure.add_modifier(
             modifier_name="SetCoreCoolingCoP",
             modifier_prop="cooling_cop",
             default=0.01,
-            object_address=["Core", "Conditioning"],
-            object_parameter="CoolingCoeffOfPerf",
+            object_address=["Core", "Conditioning", "CoolingCoeffOfPerf"],
             validator=gtValidator,
         )
 

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -7,10 +7,10 @@ from archetypal.template.measures.measure import (
     FacadeUpgradeLow,
     FacadeUpgradeMid,
     FacadeUpgradeRegular,
-    SetFacadeConstructionThermalResistanceToEnergyStar,
+    InfiltrationMedium,
     InfiltrationRegular,
     InfiltrationTight,
-    InfiltrationMedium,
+    SetFacadeConstructionThermalResistanceToEnergyStar,
 )
 
 

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -659,7 +659,8 @@ class TestMeasure:
             assert bt.Core.Ventilation.ScheduledVentilationAch == 1.33
             assert bt.Core.Ventilation.ScheduledVentilationSchedule == umi_library.YearSchedules[0]
     
-    def test_getters_and_setters_and_equality(self):
+    def test_getters_and_setters_and_equality(self, building_templates):
+        a, _, _, _ = building_templates
         measure = Measure(
             Name="A Measure",
             Description="This is the measure"
@@ -691,6 +692,8 @@ class TestMeasure:
         pytest.raises(AssertionError, match="Measure.*already.*property.*Name")
         prop_b.Validator = None
         assert prop_b.Validator == None
+        prop_b.Default = 2
+        assert prop_b.Default == 2
 
         action_a = MeasureAction(
             Name="An action",
@@ -700,6 +703,7 @@ class TestMeasure:
             Name="An action with a different name",
             Lookup=["Perimeter", "Conditioning", "HeatingCoeffOfPerf"]
         )
+        assert action_a.determine_parameter_name(building_template=a) == "HeatingCoeffOfPerf"
 
         assert action_a.Name == "An action"
         assert action_a.Validator == None

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -1,0 +1,103 @@
+"""Test measures module."""
+import pytest
+
+from archetypal.template.measures.measure import (
+    EnergyStarUpgrade,
+    FacadeUpgradeBest,
+    FacadeUpgradeLow,
+    FacadeUpgradeMid,
+    FacadeUpgradeRegular,
+    SetFacadeConstructionThermalResistanceToEnergyStar,
+    InfiltrationRegular,
+    InfiltrationTight,
+    InfiltrationMedium,
+)
+
+
+@pytest.fixture(scope="function")
+def umi_library():
+    """Yield an umi library for tests."""
+    from archetypal import UmiTemplateLibrary
+
+    umi = UmiTemplateLibrary.open(
+        "tests/input_data/umi_samples/BostonTemplateLibrary_nodup.json"
+    )
+    yield umi
+
+
+class TestMeasure:
+    """Test Measures on UmiTemplateLibraries."""
+
+    def test_apply_measure_to_single_building_template(self, umi_library):
+        """Test applying measure only to a specific building template."""
+        building_template = umi_library.BuildingTemplates[0]
+
+        assert umi_library.BuildingTemplates[0].Core.Loads.LightingPowerDensity == 12.0
+
+        EnergyStarUpgrade().apply_measure_to_template(building_template)
+
+        assert umi_library.BuildingTemplates[0].Core.Loads.LightingPowerDensity == 8.07
+        assert umi_library.BuildingTemplates[1].Core.Loads.LightingPowerDensity == 16.0
+
+    def test_apply_measure_to_whole_library(self, umi_library):
+        """Test applying measure to whole template library."""
+        assert umi_library.BuildingTemplates[0].Core.Loads.LightingPowerDensity == 12.0
+
+        # apply the measure
+        EnergyStarUpgrade().apply_measure_to_whole_library(umi_library)
+
+        # Assert the value has changed for all ZoneLoads objects.
+        for zone_loads in umi_library.ZoneLoads:
+            assert zone_loads.LightingPowerDensity == 8.07
+
+        oc = umi_library.BuildingTemplates[3].Perimeter.Constructions.Facade
+        previous_thickness = oc.total_thickness
+        previous_r_value = oc.r_value
+
+        measure = SetFacadeConstructionThermalResistanceToEnergyStar(
+            rsi_value_facade=3.08, rsi_value_roof=7.2
+        )
+        measure.apply_measure_to_whole_library(umi_library)
+
+        # assert that the total wall r_value has increased.
+        assert oc.r_value > previous_r_value
+
+        # assert that the total wall thickness has increased since setting the
+        # r-value increases the thickness of the material.
+        assert oc.total_thickness > previous_thickness
+
+    @pytest.mark.parametrize(
+        "measure",
+        [
+            FacadeUpgradeBest(),
+            FacadeUpgradeMid(),
+            FacadeUpgradeRegular(),
+            FacadeUpgradeLow(),
+        ],
+    )
+    def test_facade_upgrade(self, measure, umi_library):
+        """Test series of facade upgrades using parametrization."""
+        # apply the measure
+        facade = umi_library.BuildingTemplates[3].Perimeter.Constructions.Facade
+        i = facade.infer_insulation_layer()
+        oc = facade.Layers[i]
+
+        measure.apply_measure_to_whole_library(umi_library)
+
+        # assert that the total wall r_value has increased.
+        assert oc.r_value == pytest.approx(measure.rsi_value_facade)
+
+    @pytest.mark.parametrize(
+        "measure, infiltration_ach",
+        [
+            (InfiltrationRegular(), 0.6),
+            (InfiltrationMedium(), 0.3),
+            (InfiltrationTight(), 0.1),
+        ],
+    )
+    def test_infiltration_upgrade(self, measure, infiltration_ach, umi_library):
+        """Test applying the infiltration measures."""
+        measure.apply_measure_to_whole_library(umi_library)
+
+        for bldg in umi_library.BuildingTemplates:
+            assert bldg.Perimeter.Ventilation.Infiltration == infiltration_ach

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -121,6 +121,26 @@ class TestMeasure:
             assert bt.Perimeter.Loads.LightingPowerDensity == lighting_alt
             assert bt.Core.Loads.LightingPowerDensity == lighting_alt
 
+    def test_create_measure_with_shortcut(self, umi_library):
+        """Test creating a measure and property with the action creator shortcut via Lookup"""
+        prop = MeasureProperty(
+            Name="Ventilation ACH",
+            AttrName="VentilationACH",
+            Description="Cange Ventilation ACH",
+            Default=1.2,
+            Lookup=["Perimeter", "Ventilation", "ScheduledVentilationAch"]
+        )
+        measure = Measure(
+            Name="Ventilation",
+            Description="Change Ventilation",
+            Properties=prop
+        )
+
+        measure.mutate_library(umi_library)
+
+        for bt in umi_library.BuildingTemplates:
+            assert bt.Perimeter.Ventilation.ScheduledVentilationAch == 1.2
+
     def test_mutate_single_building_template(self, building_templates):
         """Test applying measure only to a specific building template."""
         a, b, c, d = building_templates

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -65,14 +65,14 @@ class TestMeasure:
             AttrName="EquipmentPowerDensity",
             Description="Change Equipment Power Density",
             Default=equipment_default,
-            actions=[prerimeter_equipment_action, core_equipment_action],
+            Actions=[prerimeter_equipment_action, core_equipment_action],
         )
         lighting_prop = MeasureProperty(
             Name="Lighting Power Density",
             AttrName="LightingPowerDensity",
             Description="Change Lighting Power Density",
             Default=lighting_default,
-            actions=[prerimeter_lighting_action, core_lighting_action],
+            Actions=[prerimeter_lighting_action, core_lighting_action],
         )
         # Create measure
         loads_measure = Measure(
@@ -336,7 +336,7 @@ class TestMeasure:
             Description="Set cooling CoP conditionally",
             Default=0.01,
             Validator=gtValidator,
-            actions=action,
+            Actions=action,
         )
 
         measure.add_property(prop)
@@ -436,7 +436,7 @@ class TestMeasure:
             Description="Equipment Power Density percent improvement",
             Default=5,
             Transformer=percent_decrease,
-            actions=[core_epd_action, core_lpd_action],
+            Actions=[core_epd_action, core_lpd_action],
         )
 
         prop.add_action(

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -3,12 +3,12 @@ import pytest
 
 from archetypal.template.measures.measure import (
     Measure,
-    MeasureProperty,
     MeasureAction,
+    MeasureProperty,
     SetCOP,
     SetElectricLoadsEfficiency,
-    SetFacadeThermalResistance,
     SetFacadeInsulationThermalResistance,
+    SetFacadeThermalResistance,
     SetInfiltration,
     SetMechanicalVentilation,
 )
@@ -128,12 +128,10 @@ class TestMeasure:
             AttrName="VentilationACH",
             Description="Cange Ventilation ACH",
             Default=1.2,
-            Lookup=["Perimeter", "Ventilation", "ScheduledVentilationAch"]
+            Lookup=["Perimeter", "Ventilation", "ScheduledVentilationAch"],
         )
         measure = Measure(
-            Name="Ventilation",
-            Description="Change Ventilation",
-            Properties=prop
+            Name="Ventilation", Description="Change Ventilation", Properties=prop
         )
 
         measure.mutate_library(umi_library)
@@ -406,16 +404,12 @@ class TestMeasure:
             Description="Proportionally improve equipment efficiency",
         )
 
-        def percent_decrease(
-            original_value, proposed_transformer_value, **kwargs
-        ):
+        def percent_decrease(original_value, proposed_transformer_value, **kwargs):
             """Decrease by the transformer argument interpreted as a percentage"""
             fraction = (100 - proposed_transformer_value) / 100
             return original_value * fraction
 
-        def percent_increase(
-            original_value, proposed_transformer_value, **kwargs
-        ):
+        def percent_increase(original_value, proposed_transformer_value, **kwargs):
             """Decrease by the transformer argument interpreted as a percentage"""
             fraction = (100 + proposed_transformer_value) / 100
             return original_value * fraction
@@ -655,16 +649,14 @@ class TestMeasure:
         assert c_core_loads.EquipmentPowerDensity == 3
         assert d_peri_loads.EquipmentPowerDensity == 3
         assert d_core_loads.EquipmentPowerDensity == 3
-    
-    def test_class_inheritance(self, umi_library):
 
+    def test_class_inheritance(self, umi_library):
         class GSHPandVent(SetCOP, SetMechanicalVentilation):
             HeatingCoP = 4
             CoolingCoP = 3
             VentilationACH = 1.33
             VentilationSchedule = umi_library.YearSchedules[0]
-        
-        
+
         measure = GSHPandVent()
 
         measure.mutate(umi_library)
@@ -675,16 +667,19 @@ class TestMeasure:
             assert bt.Core.Conditioning.HeatingCoeffOfPerf == 4
             assert bt.Perimeter.Conditioning.HeatingCoeffOfPerf == 4
             assert bt.Perimeter.Ventilation.ScheduledVentilationAch == 1.33
-            assert bt.Perimeter.Ventilation.ScheduledVentilationSchedule == umi_library.YearSchedules[0]
+            assert (
+                bt.Perimeter.Ventilation.ScheduledVentilationSchedule
+                == umi_library.YearSchedules[0]
+            )
             assert bt.Core.Ventilation.ScheduledVentilationAch == 1.33
-            assert bt.Core.Ventilation.ScheduledVentilationSchedule == umi_library.YearSchedules[0]
-    
+            assert (
+                bt.Core.Ventilation.ScheduledVentilationSchedule
+                == umi_library.YearSchedules[0]
+            )
+
     def test_getters_and_setters_and_equality(self, building_templates):
         a, _, _, _ = building_templates
-        measure = Measure(
-            Name="A Measure",
-            Description="This is the measure"
-        )
+        measure = Measure(Name="A Measure", Description="This is the measure")
         assert measure.Name == "A Measure"
         assert measure.Description == "This is the measure"
 
@@ -692,14 +687,14 @@ class TestMeasure:
             Name="A Property",
             AttrName="Prop",
             Description="This is the property",
-            Default=2
+            Default=2,
         )
         prop_b = MeasureProperty(
             Name="A Property",
             AttrName="Prop",
             Description="This is the property",
             Default=3,
-            Validator=lambda x, **kwargs: x
+            Validator=lambda x, **kwargs: x,
         )
 
         assert prop_a.Name == "A Property"
@@ -716,19 +711,19 @@ class TestMeasure:
         assert prop_b.Default == 2
 
         action_a = MeasureAction(
-            Name="An action",
-            Lookup=["Perimeter", "Conditioning", "HeatingCoeffOfPerf"]
+            Name="An action", Lookup=["Perimeter", "Conditioning", "HeatingCoeffOfPerf"]
         )
         action_b = MeasureAction(
             Name="An action with a different name",
-            Lookup=["Perimeter", "Conditioning", "HeatingCoeffOfPerf"]
+            Lookup=["Perimeter", "Conditioning", "HeatingCoeffOfPerf"],
         )
-        assert action_a.determine_parameter_name(building_template=a) == "HeatingCoeffOfPerf"
+        assert (
+            action_a.determine_parameter_name(building_template=a)
+            == "HeatingCoeffOfPerf"
+        )
 
         assert action_a.Name == "An action"
         assert action_a.Validator == None
         assert action_a.Transformer == None
         assert action_a.Lookup == ["Perimeter", "Conditioning", "HeatingCoeffOfPerf"]
         assert action_a == action_b
-
-

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -120,6 +120,10 @@ class TestMeasure:
             assert bt.Perimeter.Loads.EquipmentPowerDensity == equipment_alt
             assert bt.Perimeter.Loads.LightingPowerDensity == lighting_alt
             assert bt.Core.Loads.LightingPowerDensity == lighting_alt
+            assert bt.Core.Loads in umi_library.ZoneLoads # Make sure that lib.update_components_list worked
+            assert bt.Perimeter.Loads in umi_library.ZoneLoads
+            assert bt.Perimeter in umi_library.ZoneDefinitions
+            assert bt.Core in umi_library.ZoneDefinitions
 
     def test_changelog(self, umi_library):
         measure = SetInfiltration.Tight() + SetElectricLoadsEfficiency()
@@ -734,11 +738,12 @@ class TestMeasure:
         assert d_core_loads.EquipmentPowerDensity == 3
 
     def test_class_inheritance(self, umi_library):
+        schedule_to_use = umi_library.YearSchedules[0]
         class GSHPandVent(SetCOP, SetMechanicalVentilation):
             HeatingCoP = 4
             CoolingCoP = 3
             VentilationACH = 1.33
-            VentilationSchedule = umi_library.YearSchedules[0]
+            VentilationSchedule = schedule_to_use
 
         measure = GSHPandVent()
 
@@ -752,12 +757,12 @@ class TestMeasure:
             assert bt.Perimeter.Ventilation.ScheduledVentilationAch == 1.33
             assert (
                 bt.Perimeter.Ventilation.ScheduledVentilationSchedule
-                == umi_library.YearSchedules[0]
+                == schedule_to_use
             )
             assert bt.Core.Ventilation.ScheduledVentilationAch == 1.33
             assert (
                 bt.Core.Ventilation.ScheduledVentilationSchedule
-                == umi_library.YearSchedules[0]
+                == schedule_to_use
             )
 
     def test_getters_and_setters_and_equality(self, building_templates):

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -121,6 +121,65 @@ class TestMeasure:
             assert bt.Perimeter.Loads.LightingPowerDensity == lighting_alt
             assert bt.Core.Loads.LightingPowerDensity == lighting_alt
 
+    def test_changelog(self, umi_library):
+        measure = SetInfiltration.Tight() + SetElectricLoadsEfficiency()
+        original_values = []
+        for bt in umi_library.BuildingTemplates:
+            original_values.append(
+                {
+                    "Infiltration": bt.Perimeter.Ventilation.Infiltration,
+                    "PerimeterEPD": bt.Perimeter.Loads.EquipmentPowerDensity,
+                    "CoreEPD": bt.Core.Loads.EquipmentPowerDensity,
+                    "PerimeterLPD": bt.Perimeter.Loads.LightingPowerDensity,
+                    "CoreLPD": bt.Core.Loads.LightingPowerDensity,
+                }
+            )
+        changelog = measure.changelog(umi_library)
+        assert len(changelog) == len(umi_library.BuildingTemplates)
+        for original_value, bt in zip(original_values, umi_library.BuildingTemplates):
+            assert (
+                original_value["Infiltration"] == bt.Perimeter.Ventilation.Infiltration
+            )
+            assert (
+                original_value["PerimeterEPD"]
+                == bt.Perimeter.Loads.EquipmentPowerDensity
+            )
+            assert original_value["CoreEPD"] == bt.Core.Loads.EquipmentPowerDensity
+            assert (
+                original_value["PerimeterLPD"]
+                == bt.Perimeter.Loads.LightingPowerDensity
+            )
+            assert original_value["CoreLPD"] == bt.Core.Loads.LightingPowerDensity
+            assert len(changelog[bt]) == 5
+            for change in changelog[bt]:
+                assert change in [
+                    (
+                        ["Perimeter", "Ventilation", "Infiltration"],
+                        original_value["Infiltration"],
+                        measure.Infiltration,
+                    ),
+                    (
+                        ["Core", "Loads", "EquipmentPowerDensity"],
+                        original_value["CoreEPD"],
+                        measure.EquipmentPowerDensity,
+                    ),
+                    (
+                        ["Perimeter", "Loads", "EquipmentPowerDensity"],
+                        original_value["PerimeterEPD"],
+                        measure.EquipmentPowerDensity,
+                    ),
+                    (
+                        ["Core", "Loads", "LightingPowerDensity"],
+                        original_value["CoreLPD"],
+                        measure.LightingPowerDensity,
+                    ),
+                    (
+                        ["Perimeter", "Loads", "LightingPowerDensity"],
+                        original_value["PerimeterLPD"],
+                        measure.LightingPowerDensity,
+                    ),
+                ]
+
     def test_create_measure_with_shortcut(self, umi_library):
         """Test creating a measure and property with the action creator shortcut via Lookup"""
         prop = MeasureProperty(

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -779,6 +779,12 @@ class TestMeasure:
             Default=3,
             Validator=lambda x, **kwargs: x,
         )
+        prop_c = MeasureProperty(
+            Name="Another Property",
+            AttrName="PropC",
+            Description="This is the property",
+            Default=2,
+        )
 
         assert prop_a.Name == "A Property"
         assert prop_a.Description == "This is the property"
@@ -787,11 +793,32 @@ class TestMeasure:
         assert prop_a.Transformer == None
         assert prop_a == prop_b
         measure.add_property(prop_a)
-        pytest.raises(AssertionError, match="Measure.*already.*property.*Name")
+        assert measure.Properties == {prop_a}
+
+        with pytest.raises(AssertionError, match="Measure.*already.*property.*Name"):
+            measure.add_property(prop_b)
+        prop_b._name = "other name"  # unsafely set name for testing purposes
+        with pytest.raises(
+            AssertionError, match="Measure.*already.*property.*AttrName"
+        ):
+            measure.add_property(prop_b)
+
         prop_b.Validator = None
         assert prop_b.Validator == None
         prop_b.Default = 2
         assert prop_b.Default == 2
+        assert measure.get_property(prop_c.AttrName) is None
+        measure.add_property(prop_c)
+        assert prop_c == measure.get_property(prop_c.AttrName)
+        measure.remove_property(Name=prop_c.Name)
+        assert measure.get_property(prop_c.AttrName) is None
+        assert measure.get_property(Name=prop_c.Name) is None
+        assert measure.PropAttrs == [prop_a.AttrName]
+        assert measure.PropNames == [prop_a.Name]
+        measure.Properties = prop_c
+        assert measure.Properties == {prop_c}
+        measure.Properties = [prop_c, prop_a]
+        assert measure.Properties == {prop_c, prop_a}
 
         action_a = MeasureAction(
             Name="An action", Lookup=["Perimeter", "Conditioning", "HeatingCoeffOfPerf"]

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -139,6 +139,30 @@ class TestMeasure:
         for bt in umi_library.BuildingTemplates:
             assert bt.Perimeter.Ventilation.ScheduledVentilationAch == 1.2
 
+    def test_add_and_iadd_measures(self, umi_library):
+        measure_a = SetCOP(HeatingCoP=4, CoolingCoP=4)
+        measure_b = SetInfiltration(Infiltration=0.1)
+        measure_c = measure_a + measure_b
+        measure_c.mutate(umi_library)
+        for bt in umi_library.BuildingTemplates:
+            assert bt.Core.Conditioning.HeatingCoeffOfPerf == 4
+            assert bt.Perimeter.Conditioning.HeatingCoeffOfPerf == 4
+            assert bt.Core.Conditioning.CoolingCoeffOfPerf == 4
+            assert bt.Perimeter.Conditioning.CoolingCoeffOfPerf == 4
+            assert bt.Perimeter.Ventilation.Infiltration == 0.1
+
+        measure_a += measure_b
+        measure_a.HeatingCoP = 5
+        measure_a.CoolingCoP = 5
+        measure_a.Infiltration = 0.05
+        measure_a.mutate(umi_library)
+        for bt in umi_library.BuildingTemplates:
+            assert bt.Core.Conditioning.HeatingCoeffOfPerf == 5
+            assert bt.Perimeter.Conditioning.HeatingCoeffOfPerf == 5
+            assert bt.Core.Conditioning.CoolingCoeffOfPerf == 5
+            assert bt.Perimeter.Conditioning.CoolingCoeffOfPerf == 5
+            assert bt.Perimeter.Ventilation.Infiltration == 0.05
+
     def test_mutate_single_building_template(self, building_templates):
         """Test applying measure only to a specific building template."""
         a, b, c, d = building_templates

--- a/tests/test_umi.py
+++ b/tests/test_umi.py
@@ -63,14 +63,14 @@ class TestUmiTemplate:
         # Only make the `OpaqueMaterial` objects unique.
         nb_materials_before = len(c.OpaqueMaterials)
         nb_opaque_constructions = len(c.OpaqueConstructions)
-        c.unique_components("OpaqueMaterials")
+        c.unique_components(keep_orphaned="OpaqueMaterials")
         assert len(c.OpaqueMaterials) < nb_materials_before
         assert len(c.OpaqueConstructions) == nb_opaque_constructions
 
         # test wrong inclusion
         with pytest.raises(AssertionError):
             # missing S.
-            c.unique_components("OpaqueMaterial")
+            c.unique_components(keep_orphaned="OpaqueMaterial")
 
     def test_graph(self):
         """Test initialization of networkx DiGraph"""

--- a/tests/test_umi.py
+++ b/tests/test_umi.py
@@ -84,6 +84,11 @@ class TestUmiTemplate:
         G = a.to_graph(include_orphans=True)
         assert len(G) > n_nodes
 
+    def test_object_by_id(self, two_identical_libraries):
+        """Test getting an object by its id."""
+        lib, _ = two_identical_libraries
+        assert lib.objects_by_id["1"].id == "1"
+
     def test_template_to_template(self):
         """load the json into UmiTemplateLibrary object, then convert back to json and
         compare"""


### PR DESCRIPTION
Expands on the original features commit to implement some notion of a change log while also simplifying the syntax for users to define their own measures, while still allowing for dynamic measures.

Not yet ready to merge, but I have added some notes and discussion points below.

Tried to be detailed so that the vision for it is clear!

Once it's ready to commit, I can fill in `measures/README.md`

### The add_modifier method

The method handles adding named props to the measure as attrs, constructing a lambda which will mutate building templates once provided (stored in the measure as an attr), and constructing lambdas which handle generating changelog previews.

This is the major update to the library.  It provides an API for defining custom measures which mutate both static and dynamic paths (i.e. an insulation layer), so it should cover the majority of use cases.  It does not yet support using computed values based off input building templates, but it shouldn't be too hard to integrate those.  It also potentially makes measures serializable, at least those which do not rely on dynamic pathfinding or computed values, however I have not yet implemented any serializer methods.

The basic idea is that users will:
1. Declare a new class which inherits `Measure` as before
2. In the `__init__` method for their class, they call `self.add_modifier` with the relevant args for an action that the measure executes. 
3. repeat step 2 for as many actions as they would like the measure to include

Args:

- `modifier_name: string` - the name of the action.  this ends up as the attr name for the action callback (as before, e.g. `SetPerimeterCoolingCop`) which will ultimately get called when applying the measure.
- `modifier_prop: string` - the name of the attr which will store the value to use (e.g. `cooling_cop`).  Users can then later change the value if they wish to mutate the measure's action, e.g. `myCOPmeasure.cooling_cop = 2` and the measure will be dynamically updated to handle the new action, since the mutators dynamically reference this attr.  Modifier actions which are created with the same `modifier_prop` value will use a shared prop (e.g. `cooling_cop` can be used for the action which modifies perimeter and core cooling COPs).  These values can also be initialized as class attributes, but they will always be converted to instance vars at runtime (i.e. always accessed by `getattr(self,modifier_prop)`
- `default: any` - the value which will be used to overwrite the targeted path for the modifier action.  Typically a number, but it *should* probably still work passing in an object, though I have not tested yet.  That does suggest the ability to define the upgrade as completely replacing one window entire construction with another, for instance.
- `object_address: list<str | int> | (BuildingTemplate): list<str | int> - where to find the parameter to mutate - e.g. `[ "Perimeter", "Ventilation"]`.  It can also accept a function which takes in the building template and constructs the path dynamically (this is done in the thermal insulation upgrade measure).  The path can be a mixture of string keys and indices as well (also shown in the insulation upgrade).  It might be nice to allow this to be specified as a `.` separated string rather in addition to an array, but that can be an easy future feature to add.
- `object_parameter: str | int | (building_template: BuildingTemplate, object_address: any): str | int" - the name or index of the final entity to mutate in the template (e.g. `ScheduledVentilationAch`).  it can also be a function which dynamically determines the parameter name/index.
- `validator: (original_value: any, new_value: any, root: any): boolean` - this is an optional function which can be provided to provide a test which will run before applying the modification action - e.g. to prevent lowering a parameter if desired.  the building_template will also be supplied to the root argument if any contextual validation needs to be done.  The API for this maybe needs a little work, I think it will break if you don't declare your validator with a root arg, even if it is unused.

Here is an example of how it is used, in the `SetCOP` measure's `__init__` method:
```
self.add_modifier(
    modifier_name="SetCoreCoolingCop",
    modifier_prop="cooling_cop",
    default=cooling_cop,
    object_address=["Core", "Conditioning"],
    object_parameter="CoolingCoeffOfPerf",
)
self.add_modifier(
    modifier_name="SetPerimeterCoolingCop",
    modifier_prop="cooling_cop",
    object_address=["Perimeter", "Conditioning"],
    object_parameter="CoolingCoeffOfPerf",
)
```

For now, I have left `add_modifier` as a plain method, but w could easily imagine bundling it up into a small class.

The next thing to do would be to add support for computed values - e.g. an argument with a name like `compute` which takes in a function that computes the new value dynamically based off of data in the template.  I seemed to recall that you mentioned there was a method somewhere for setting the r-value of a wall to a specific value by dynamically resizing the insulation layer, which is an obvious candidate for testing that functionality.  I noticed that the existing insulation upgrade which was already written was just using fixed values as of now.






### Changelog methods

https://github.com/szvsw/archetypal/blob/f8d1560c0ae2ec0966f0cd6f5462144a1fee63a0/archetypal/template/measures/measure.py#L74

These methods generate a changelog, or really, a schedule of what *will* be changed if the measure is applied.  The main utility here is being able to preview to the user changes that will be executed - use case for me would be in `ubem.io` as a person is deciding what measures to apply.  Maybe we just need to pick a better name for these methods.

Another thing to consider might be abstracting a change into a small `Change` class but that is maybe overkill. 

changelog should be able to handle dynamic values but it can't quite yet




### Args at runtime
Forgot about these while I was working, so I have not integrated these into the modifier actions yet, but it shouldn't be hard.  Can you give me an example of a measure where you might imagine passing runtime args?
https://github.com/szvsw/archetypal/blob/f8d1560c0ae2ec0966f0cd6f5462144a1fee63a0/archetypal/template/measures/measure.py#L68


### Accessing Deeply Nested Attrs

These are a few module-level helper functions.

https://github.com/szvsw/archetypal/blob/f8d1560c0ae2ec0966f0cd6f5462144a1fee63a0/archetypal/template/measures/measure.py#L10

When specifying upgrades, the user will define a path to a parameter as an array of attr names (or a dynamic path constructor). These functions are used to get/set deeply nested attributes/values within a building template based off of a path array.  I wasn't sure if there was something like this in the library already, but it was simple enough to write.  It may in fact be worth it to adapt these a little bit and insert them at the umi template level?  

Another convenient thing to do might be to allow the user to provide the path in a single string, and then generate the array by splitting it on `.` symbols.


### Future

- measure arithmetic - it would be pretty easy to imagine an `__add__` method for `Measures` - it would be especially easy if we wrapped up the action_modifiers into a small class, as then the modifiers could be stored as a list in the measure and then it would just be list concatenation.  still very simple to do as is.
- serialization - some measures are serializable (i.e. those which only make use of fixed paths and serializable values to write into those paths).  I'm not sure how useful this is, but it could be interesting?


