### PR TITLE
An issue affecting invalid GasMaterial names has been fixed

### DIFF
--- a/archetypal/template/materials/gas_material.py
+++ b/archetypal/template/materials/gas_material.py
@@ -33,14 +33,32 @@ class GasMaterial(MaterialBase):
             Category (str): Category is set as "Gases" for GasMaterial.
             **kwargs: keywords passed to the MaterialBase constructor.
         """
-        super(GasMaterial, self).__init__(Name, Category=Category, **kwargs)
+        self.Name = Name
+        super(GasMaterial, self).__init__(self.Name, Category=Category, **kwargs)
         self.Type = Name.upper()
         self.Conductivity = Conductivity
         self.Density = Density
 
     @property
+    def Name(self):
+        """Get or set the name of the GasMaterial.
+
+        Choices are ("Air", "Argon", "Krypton", "Xenon").
+        """
+        return self._name
+
+    @Name.setter
+    def Name(self, value):
+        assert value.lower() in self._GASTYPES, (
+            f"Invalid value '{value}' for material gas type. Gas type must be one "
+            f"of the following:\n{self._GASTYPES}"
+        )
+        self._type = value.upper()
+        self._name = value.title()
+
+    @property
     def Type(self):
-        """Get or set the gas type.
+        """Get or set the gas type. Alias of Name.
 
         Choices are ("Air", "Argon", "Krypton", "Xenon").
         """
@@ -52,7 +70,8 @@ class GasMaterial(MaterialBase):
             f"Invalid value '{value}' for material gas type. Gas type must be one "
             f"of the following:\n{self._GASTYPES}"
         )
-        self._type = value
+        self._type = value.upper()
+        self._name = value.title()
 
     @property
     def Conductivity(self):
@@ -73,7 +92,7 @@ class GasMaterial(MaterialBase):
 
     @Density.setter
     def Density(self, value):
-        """Density of the gas at 0C and sea-level pressure [J/kg-K]."""
+        """Density of the gas at 0C and sea-level pressure [kg/m3]."""
         if value is not None:
             self._density = validators.float(value, minimum=0)
         else:

--- a/archetypal/template/materials/gas_material.py
+++ b/archetypal/template/materials/gas_material.py
@@ -54,7 +54,7 @@ class GasMaterial(MaterialBase):
             f"of the following:\n{self._GASTYPES}"
         )
         self._type = value.upper()
-        self._name = value.title()
+        self._name = value
 
     @property
     def Type(self):
@@ -71,7 +71,7 @@ class GasMaterial(MaterialBase):
             f"of the following:\n{self._GASTYPES}"
         )
         self._type = value.upper()
-        self._name = value.title()
+        self._name = value
 
     @property
     def Conductivity(self):

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -968,13 +968,9 @@ class TestGasMaterial:
         gm_dict = {gm: "this_idf", gm_2: "same_idf"}
         assert len(gm_dict) == 1
 
-        gm_2.Name = "some other name"
-        # even if name changes, they should be equal
-        assert gm_2 == gm
-
         gm_dict = {gm: "this_idf", gm_2: "same_idf"}
         assert gm in gm_dict
-        assert len(gm_dict) == 2
+        assert len(gm_dict) == 1
 
         # if an attribute changed, equality is lost
         gm_2.Cost = 69
@@ -984,12 +980,9 @@ class TestGasMaterial:
         # don't have the same hash.
         assert len(set(gm_list)) == 2
 
-        # 2 GasMaterial from same json should not have the same hash if they
-        # have different names, not be the same object, yet be equal if they have the
-        # same layers (Material and Thickness)
+        # Test copy
         gm_3 = gm.duplicate()
-        gm_3.Name = "other name"
-        assert hash(gm) != hash(gm_3)
+        assert hash(gm) == hash(gm_3)
         assert id(gm) != id(gm_3)
         assert gm is not gm_3
         assert gm == gm_3


### PR DESCRIPTION
The GasMaterial.Name class now has a Name validator.