### PR TITLE
IsScheduledVentilationOn=True allowed when ScheduledVentilationAch=0

### DIFF
--- a/archetypal/template/ventilation.py
+++ b/archetypal/template/ventilation.py
@@ -300,7 +300,7 @@ class VentilationSetting(UmiBase):
         )
         if value:
             assert (
-                self.ScheduledVentilationAch > 0
+                self.ScheduledVentilationAch >= 0
                 and self.ScheduledVentilationSchedule is not None
             ), (
                 f"IsScheduledVentilationOn cannot be 'True' if ScheduledVentilationAch "


### PR DESCRIPTION
Fixes an issue affecting IECC prototype buildings