### PR TITLE
Performance improvements for large UmiTemplateLibraries

### DIFF
--- a/archetypal/template/building_template.py
+++ b/archetypal/template/building_template.py
@@ -583,7 +583,7 @@ class BuildingTemplate(UmiBase):
         recursive_replace(self)
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/building_template.py
+++ b/archetypal/template/building_template.py
@@ -565,7 +565,7 @@ class BuildingTemplate(UmiBase):
         """Replace recursively every objects with the first equivalent object."""
 
         def recursive_replace(umibase):
-            for key, obj in umibase.mapping().items():
+            for key, obj in umibase.mapping(validate=False).items():
                 if isinstance(
                     obj, (UmiBase, MaterialLayer, YearSchedulePart, MassRatio)
                 ):

--- a/archetypal/template/building_template.py
+++ b/archetypal/template/building_template.py
@@ -31,6 +31,7 @@ class BuildingTemplate(UmiBase):
 
     .. image:: ../images/template/buildingtemplate.png
     """
+    _CREATED_OBJECTS = []
 
     __slots__ = (
         "_partition_ratio",
@@ -114,8 +115,8 @@ class BuildingTemplate(UmiBase):
         self.AuthorEmails = AuthorEmails if AuthorEmails else []
         self.Version = Version
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def Perimeter(self):

--- a/archetypal/template/building_template.py
+++ b/archetypal/template/building_template.py
@@ -367,11 +367,11 @@ class BuildingTemplate(UmiBase):
         # do core and Perim zone reduction
         bt = cls.reduced_model(name, zones, **kwargs)
 
-        if not bt.Core.DomesticHotWater or not bt.Perimeter.DomesticHotWater:
+        if bt.Core.DomesticHotWater is None or bt.Perimeter.DomesticHotWater is None:
             dhw = DomesticHotWaterSetting.whole_building(idf)
-            if not bt.Core.DomesticHotWater:
+            if bt.Core.DomesticHotWater is None:
                 bt.Core.DomesticHotWater = dhw
-            if not bt.Perimeter.DomesticHotWater:
+            if bt.Perimeter.DomesticHotWater is None:
                 bt.Perimeter.DomesticHotWater = dhw
 
         bt.Comments = "\n".join(

--- a/archetypal/template/conditioning.py
+++ b/archetypal/template/conditioning.py
@@ -1495,7 +1495,7 @@ class ZoneConditioning(UmiBase):
         if self.MinFreshAirPerArea is None:
             self.MinFreshAirPerArea = 0
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/conditioning.py
+++ b/archetypal/template/conditioning.py
@@ -88,6 +88,7 @@ class ZoneConditioning(UmiBase):
 
     .. image:: ../images/template/zoninfo-conditioning.png
     """
+    _CREATED_OBJECTS = []
 
     __slots__ = (
         "_cooling_setpoint",
@@ -285,8 +286,8 @@ class ZoneConditioning(UmiBase):
 
         self.area = area
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def area(self):

--- a/archetypal/template/conditioning.py
+++ b/archetypal/template/conditioning.py
@@ -1488,11 +1488,11 @@ class ZoneConditioning(UmiBase):
             self.CoolingSchedule = UmiSchedule.constant_schedule()
         if self.MechVentSchedule is None:
             self.MechVentSchedule = UmiSchedule.constant_schedule()
-        if not self.IsMechVentOn:
+        if self.IsMechVentOn is None:
             self.IsMechVentOn = False
-        if not self.MinFreshAirPerPerson:
+        if self.MinFreshAirPerPerson is None:
             self.MinFreshAirPerPerson = 0
-        if not self.MinFreshAirPerArea:
+        if self.MinFreshAirPerArea is None:
             self.MinFreshAirPerArea = 0
 
     def mapping(self, validate=True):

--- a/archetypal/template/constructions/opaque_construction.py
+++ b/archetypal/template/constructions/opaque_construction.py
@@ -465,7 +465,7 @@ class OpaqueConstruction(LayeredConstruction):
             # Iterate over the construction's layers
             material = epbunch.get_referenced_object(layer)
             if material:
-                o = OpaqueMaterial.from_epbunch(material, allow_duplicates=True)
+                o = OpaqueMaterial.from_epbunch(material, allow_duplicates=False)
                 try:
                     thickness = material.Thickness
                 except BadEPFieldError:

--- a/archetypal/template/constructions/opaque_construction.py
+++ b/archetypal/template/constructions/opaque_construction.py
@@ -31,6 +31,8 @@ class OpaqueConstruction(LayeredConstruction):
         * solar_reflectance_index
     """
 
+    _CREATED_OBJECTS = []
+
     __slots__ = ("area",)
 
     def __init__(self, Name, Layers, **kwargs):
@@ -45,8 +47,8 @@ class OpaqueConstruction(LayeredConstruction):
         super(OpaqueConstruction, self).__init__(Name, Layers, **kwargs)
         self.area = 1
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def r_value(self):

--- a/archetypal/template/constructions/opaque_construction.py
+++ b/archetypal/template/constructions/opaque_construction.py
@@ -493,7 +493,7 @@ class OpaqueConstruction(LayeredConstruction):
 
         return data_dict
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/constructions/opaque_construction.py
+++ b/archetypal/template/constructions/opaque_construction.py
@@ -408,7 +408,7 @@ class OpaqueConstruction(LayeredConstruction):
         return OpaqueConstruction(
             Name="InternalMass",
             Layers=[MaterialLayer(Material=mat, Thickness=0.15)],
-            Category="InternalMass",
+            Category="Internal Mass",
             **kwargs,
         )
 

--- a/archetypal/template/constructions/window_construction.py
+++ b/archetypal/template/constructions/window_construction.py
@@ -337,7 +337,7 @@ class WindowConstruction(LayeredConstruction):
 
         return idf.newidfobject("CONSTRUCTION", **data)
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/constructions/window_construction.py
+++ b/archetypal/template/constructions/window_construction.py
@@ -63,6 +63,8 @@ class WindowConstruction(LayeredConstruction):
     .. image:: ../images/template/constructions-window.png
     """
 
+    _CREATED_OBJECTS = []
+
     _CATEGORIES = ("single", "double", "triple", "quadruple")
 
     __slots__ = ("_category",)
@@ -85,8 +87,8 @@ class WindowConstruction(LayeredConstruction):
         )
         self.Category = Category  # set here for validators
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def Category(self):

--- a/archetypal/template/dhw.py
+++ b/archetypal/template/dhw.py
@@ -19,6 +19,7 @@ class DomesticHotWaterSetting(UmiBase):
 
     .. image:: ../images/template/zoneinfo-dhw.png
     """
+    _CREATED_OBJECTS = []
 
     __slots__ = (
         "_flow_rate_per_floor_area",
@@ -61,8 +62,8 @@ class DomesticHotWaterSetting(UmiBase):
         self.WaterSchedule = WaterSchedule
         self.area = area
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def FlowRatePerFloorArea(self):

--- a/archetypal/template/dhw.py
+++ b/archetypal/template/dhw.py
@@ -470,7 +470,7 @@ class DomesticHotWaterSetting(UmiBase):
 
         return reduce(DomesticHotWaterSetting.combine, z_dhw_list)
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/load.py
+++ b/archetypal/template/load.py
@@ -623,7 +623,7 @@ class ZoneLoad(UmiBase):
             self.PeopleDensity = 0
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/load.py
+++ b/archetypal/template/load.py
@@ -42,6 +42,7 @@ class ZoneLoad(UmiBase):
 
     .. image:: ../images/template/zoneinfo-loads.png
     """
+    _CREATED_OBJECTS = []
 
     __slots__ = (
         "_dimming_type",
@@ -131,8 +132,8 @@ class ZoneLoad(UmiBase):
         self.area = area
         self.volume = volume
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def DimmingType(self):

--- a/archetypal/template/load.py
+++ b/archetypal/template/load.py
@@ -599,27 +599,27 @@ class ZoneLoad(UmiBase):
 
     def validate(self):
         """Validate object and fill in missing values."""
-        if not self.DimmingType:
+        if self.DimmingType is None:
             self.DimmingType = DimmingTypes.Continuous
-        if not self.EquipmentAvailabilitySchedule:
+        if self.EquipmentAvailabilitySchedule is None:
             self.EquipmentAvailabilitySchedule = UmiSchedule.constant_schedule()
-        if not self.EquipmentPowerDensity:
+        if self.EquipmentPowerDensity is None:
             self.EquipmentPowerDensity = 0
-        if not self.IlluminanceTarget:
+        if self.IlluminanceTarget is None:
             self.IlluminanceTarget = 500
-        if not self.LightingPowerDensity:
+        if self.LightingPowerDensity is None:
             self.LightingPowerDensity = 0
-        if not self.LightsAvailabilitySchedule:
+        if self.LightsAvailabilitySchedule is None:
             self.LightsAvailabilitySchedule = UmiSchedule.constant_schedule()
-        if not self.OccupancySchedule:
+        if self.OccupancySchedule is None:
             self.OccupancySchedule = UmiSchedule.constant_schedule()
-        if not self.IsEquipmentOn:
+        if self.IsEquipmentOn is None:
             self.IsEquipmentOn = False
-        if not self.IsLightingOn:
+        if self.IsLightingOn is None:
             self.IsLightingOn = False
-        if not self.IsPeopleOn:
+        if self.IsPeopleOn is None:
             self.IsPeopleOn = False
-        if not self.PeopleDensity:
+        if self.PeopleDensity is None:
             self.PeopleDensity = 0
         return self
 

--- a/archetypal/template/materials/gas_material.py
+++ b/archetypal/template/materials/gas_material.py
@@ -14,6 +14,7 @@ class GasMaterial(MaterialBase):
 
     .. image:: ../images/template/materials-gas.png
     """
+    _CREATED_OBJECTS = []
 
     __slots__ = ("_type", "_conductivity", "_density")
 
@@ -39,8 +40,8 @@ class GasMaterial(MaterialBase):
         self.Conductivity = Conductivity
         self.Density = Density
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def Name(self):

--- a/archetypal/template/materials/gas_material.py
+++ b/archetypal/template/materials/gas_material.py
@@ -178,7 +178,7 @@ class GasMaterial(MaterialBase):
             Thickness=thickness,
         )
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/materials/glazing_material.py
+++ b/archetypal/template/materials/glazing_material.py
@@ -365,7 +365,7 @@ class GlazingMaterial(MaterialBase):
             Dirt_Correction_Factor_for_Solar_and_Visible_Transmittance=self.DirtFactor,
         )
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/materials/glazing_material.py
+++ b/archetypal/template/materials/glazing_material.py
@@ -17,6 +17,7 @@ class GlazingMaterial(MaterialBase):
     .. image:: ../images/template/materials-glazing.png
 
     """
+    _CREATED_OBJECTS = []
 
     __slots__ = (
         "_ir_emissivity_back",
@@ -104,8 +105,8 @@ class GlazingMaterial(MaterialBase):
         self.SolarReflectanceFront = SolarReflectanceFront
         self.SolarTransmittance = SolarTransmittance
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def Conductivity(self):

--- a/archetypal/template/materials/material_layer.py
+++ b/archetypal/template/materials/material_layer.py
@@ -2,6 +2,7 @@
 
 import collections
 import logging as lg
+import math
 
 from sigfig import round
 from validator_collection import validators
@@ -143,7 +144,10 @@ class MaterialLayer(object):
             return NotImplemented
         else:
             return all(
-                [self.Thickness == other.Thickness, self.Material == other.Material]
+                [
+                    math.isclose(self.Thickness, other.Thickness, abs_tol=0.001),
+                    self.Material == other.Material,
+                ]
             )
 
     def __repr__(self):

--- a/archetypal/template/materials/nomass_material.py
+++ b/archetypal/template/materials/nomass_material.py
@@ -390,7 +390,7 @@ class NoMassMaterial(MaterialBase):
             setattr(self, "VisibleAbsorptance", 0.7)
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/materials/nomass_material.py
+++ b/archetypal/template/materials/nomass_material.py
@@ -14,6 +14,8 @@ from archetypal.utils import log
 class NoMassMaterial(MaterialBase):
     """Use this component to create a custom no mass material."""
 
+    _CREATED_OBJECTS = []
+
     _ROUGHNESS_TYPES = (
         "VeryRough",
         "Rough",
@@ -77,8 +79,8 @@ class NoMassMaterial(MaterialBase):
         self.VisibleAbsorptance = VisibleAbsorptance
         self.MoistureDiffusionResistance = MoistureDiffusionResistance
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def r_value(self):

--- a/archetypal/template/materials/opaque_material.py
+++ b/archetypal/template/materials/opaque_material.py
@@ -7,7 +7,7 @@ from validator_collection import validators
 
 from archetypal.template.materials import GasMaterial
 from archetypal.template.materials.material_base import MaterialBase
-from archetypal.utils import log
+from archetypal.utils import log, signif
 
 
 class OpaqueMaterial(MaterialBase):
@@ -133,7 +133,8 @@ class OpaqueMaterial(MaterialBase):
 
     @Conductivity.setter
     def Conductivity(self, value):
-        self._conductivity = validators.float(value, minimum=0)
+        value = validators.float(value, minimum=0)
+        self._conductivity = signif(value)
 
     @property
     def Density(self):
@@ -142,7 +143,8 @@ class OpaqueMaterial(MaterialBase):
 
     @Density.setter
     def Density(self, value):
-        self._density = validators.float(value, minimum=0)
+        value = validators.float(value, minimum=0)
+        self._density = signif(value)
 
     @property
     def Roughness(self):
@@ -182,7 +184,8 @@ class OpaqueMaterial(MaterialBase):
 
     @SpecificHeat.setter
     def SpecificHeat(self, value):
-        self._specific_heat = validators.float(value, minimum=100)
+        value = validators.float(value, minimum=100)
+        self._specific_heat = signif(value)
 
     @property
     def ThermalEmittance(self):

--- a/archetypal/template/materials/opaque_material.py
+++ b/archetypal/template/materials/opaque_material.py
@@ -16,6 +16,8 @@ class OpaqueMaterial(MaterialBase):
     .. image:: ../images/template/materials-opaque.png
     """
 
+    _CREATED_OBJECTS = []
+
     _ROUGHNESS_TYPES = (
         "VeryRough",
         "Rough",
@@ -121,8 +123,8 @@ class OpaqueMaterial(MaterialBase):
         self._key: str = kwargs.get("_key", "")
         # TODO: replace when NoMass and AirGap when properly is supported
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def Conductivity(self):

--- a/archetypal/template/materials/opaque_material.py
+++ b/archetypal/template/materials/opaque_material.py
@@ -531,7 +531,7 @@ class OpaqueMaterial(MaterialBase):
             setattr(self, "VisibleAbsorptance", 0.7)
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/schedule.py
+++ b/archetypal/template/schedule.py
@@ -247,7 +247,7 @@ class UmiSchedule(Schedule, UmiBase):
         """Validate object and fill in missing values."""
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:
@@ -620,7 +620,7 @@ class DaySchedule(UmiSchedule):
 
         return data_dict
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:
@@ -799,7 +799,7 @@ class WeekSchedule(UmiSchedule):
 
         return data_dict
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:
@@ -1031,7 +1031,7 @@ class YearSchedule(UmiSchedule):
 
         return idf.newidfobject(key="Schedule:Year".upper(), **new_dict)
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/schedule.py
+++ b/archetypal/template/schedule.py
@@ -17,6 +17,7 @@ from archetypal.utils import log
 
 class UmiSchedule(Schedule, UmiBase):
     """Class that handles Schedules."""
+    _CREATED_OBJECTS = []
 
     __slots__ = ("_quantity",)
 
@@ -31,8 +32,8 @@ class UmiSchedule(Schedule, UmiBase):
         super(UmiSchedule, self).__init__(Name, **kwargs)
         self.quantity = quantity
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def quantity(self):
@@ -1067,7 +1068,7 @@ class YearSchedule(UmiSchedule):
                     next(
                         (
                             x
-                            for x in self.CREATED_OBJECTS
+                            for x in self._CREATED_OBJECTS
                             if x.Name == week_day_schedule_name
                             and type(x).__name__ == "WeekSchedule"
                         )

--- a/archetypal/template/structure.py
+++ b/archetypal/template/structure.py
@@ -212,7 +212,7 @@ class StructureInformation(ConstructionBase):
         """Validate object and fill in missing values."""
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/structure.py
+++ b/archetypal/template/structure.py
@@ -139,6 +139,8 @@ class StructureInformation(ConstructionBase):
     .. image:: ../images/template/constructions-structure.png
     """
 
+    _CREATED_OBJECTS = []
+
     __slots__ = ("_mass_ratios",)
 
     def __init__(self, Name, MassRatios, **kwargs):
@@ -151,8 +153,8 @@ class StructureInformation(ConstructionBase):
         super(StructureInformation, self).__init__(Name, **kwargs)
         self.MassRatios = MassRatios
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def MassRatios(self):

--- a/archetypal/template/umi_base.py
+++ b/archetypal/template/umi_base.py
@@ -55,7 +55,6 @@ class UmiBase(object):
         "_allow_duplicates",
         "_unit_number",
     )
-    CREATED_OBJECTS = []
     _ids = itertools.count(0)  # unique id for each class instance
 
     def __init__(
@@ -239,15 +238,6 @@ class UmiBase(object):
         """Return UmiBase dictionary representation."""
         return {"$id": "{}".format(self.id), "Name": "{}".format(self.Name)}
 
-    @classmethod
-    def get_classref(cls, ref):
-        return next(
-            iter(
-                [value for value in UmiBase.CREATED_OBJECTS if value.id == ref["$ref"]]
-            ),
-            None,
-        )
-
     def get_ref(self, ref):
         pass
 
@@ -380,7 +370,7 @@ class UmiBase(object):
             return other
         if other is None:
             return self
-        self.CREATED_OBJECTS.remove(self)
+        self._CREATED_OBJECTS.remove(self)
         id = self.id
         new_obj = self.combine(other, allow_duplicates=allow_duplicates)
         new_obj.id = id
@@ -419,10 +409,9 @@ class UmiBase(object):
                     sorted(
                         (
                             x
-                            for x in UmiBase.CREATED_OBJECTS
+                            for x in self._CREATED_OBJECTS
                             if x == self
                             and x.Name == self.Name
-                            and type(x) == type(self)
                         ),
                         key=lambda x: x.unit_number,
                     )
@@ -437,8 +426,7 @@ class UmiBase(object):
                     sorted(
                         (
                             x
-                            for x in UmiBase.CREATED_OBJECTS
-                            if x == self and type(x) == type(self)
+                            for x in self._CREATED_OBJECTS
                         ),
                         key=lambda x: x.unit_number,
                     )

--- a/archetypal/template/umi_base.py
+++ b/archetypal/template/umi_base.py
@@ -382,7 +382,7 @@ class UmiBase(object):
         """Validate UmiObjects and fills in missing values."""
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/umi_base.py
+++ b/archetypal/template/umi_base.py
@@ -427,6 +427,7 @@ class UmiBase(object):
                         (
                             x
                             for x in self._CREATED_OBJECTS
+                            if x == self
                         ),
                         key=lambda x: x.unit_number,
                     )

--- a/archetypal/template/ventilation.py
+++ b/archetypal/template/ventilation.py
@@ -682,11 +682,11 @@ class VentilationSetting(UmiBase):
 
     def validate(self):
         """Validate object and fill in missing values."""
-        if not self.NatVentSchedule:
+        if self.NatVentSchedule is None:
             self.NatVentSchedule = UmiSchedule.constant_schedule(
                 value=0, Name="AlwaysOff", allow_duplicates=True
             )
-        if not self.ScheduledVentilationSchedule:
+        if self.ScheduledVentilationSchedule is None:
             self.ScheduledVentilationSchedule = UmiSchedule.constant_schedule(
                 value=0, Name="AlwaysOff", allow_duplicates=True
             )
@@ -699,7 +699,8 @@ class VentilationSetting(UmiBase):
         Args:
             validate:
         """
-        self.validate()
+        if validate:
+            self.validate()
 
         return dict(
             Afn=self.Afn,

--- a/archetypal/template/ventilation.py
+++ b/archetypal/template/ventilation.py
@@ -62,6 +62,7 @@ class VentilationSetting(UmiBase):
 
     .. image:: ../images/template/zoneinfo-ventilation.png
     """
+    _CREATED_OBJECTS = []
 
     __slots__ = (
         "_infiltration",
@@ -198,8 +199,8 @@ class VentilationSetting(UmiBase):
         self.area = area
         self.volume = volume
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def NatVentSchedule(self):

--- a/archetypal/template/ventilation.py
+++ b/archetypal/template/ventilation.py
@@ -693,7 +693,7 @@ class VentilationSetting(UmiBase):
 
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/window_setting.py
+++ b/archetypal/template/window_setting.py
@@ -36,6 +36,7 @@ class WindowSetting(UmiBase):
 
     .. _eppy : https://eppy.readthedocs.io/en/latest/
     """
+    _CREATED_OBJECTS = []
 
     __slots__ = (
         "_operable_area",
@@ -131,8 +132,8 @@ class WindowSetting(UmiBase):
 
         self.area = area
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def area(self):

--- a/archetypal/template/window_setting.py
+++ b/archetypal/template/window_setting.py
@@ -883,7 +883,7 @@ class WindowSetting(UmiBase):
 
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/window_setting.py
+++ b/archetypal/template/window_setting.py
@@ -868,15 +868,15 @@ class WindowSetting(UmiBase):
 
     def validate(self):
         """Validate object and fill in missing values."""
-        if not self.AfnWindowAvailability:
+        if self.AfnWindowAvailability is None:
             self.AfnWindowAvailability = UmiSchedule.constant_schedule(
                 value=0, Name="AlwaysOff"
             )
-        if not self.ShadingSystemAvailabilitySchedule:
+        if self.ShadingSystemAvailabilitySchedule is None:
             self.ShadingSystemAvailabilitySchedule = UmiSchedule.constant_schedule(
                 value=0, Name="AlwaysOff"
             )
-        if not self.ZoneMixingAvailabilitySchedule:
+        if self.ZoneMixingAvailabilitySchedule is None:
             self.ZoneMixingAvailabilitySchedule = UmiSchedule.constant_schedule(
                 value=0, Name="AlwaysOff"
             )

--- a/archetypal/template/zone_construction_set.py
+++ b/archetypal/template/zone_construction_set.py
@@ -482,7 +482,7 @@ class ZoneConstructionSet(UmiBase):
                 )
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/zone_construction_set.py
+++ b/archetypal/template/zone_construction_set.py
@@ -12,6 +12,7 @@ from archetypal.utils import log, reduce, timeit
 
 class ZoneConstructionSet(UmiBase):
     """ZoneConstructionSet class."""
+    _CREATED_OBJECTS = []
 
     __slots__ = (
         "_facade",
@@ -80,8 +81,8 @@ class ZoneConstructionSet(UmiBase):
         self.area = area
         self.volume = volume
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def Facade(self):
@@ -463,7 +464,7 @@ class ZoneConstructionSet(UmiBase):
                     iter(
                         filter(
                             lambda x: getattr(x, attr, None) is not None,
-                            UmiBase.CREATED_OBJECTS,
+                            ZoneConstructionSet._CREATED_OBJECTS,
                         )
                     ),
                     None,

--- a/archetypal/template/zonedefinition.py
+++ b/archetypal/template/zonedefinition.py
@@ -674,7 +674,7 @@ class ZoneDefinition(UmiBase):
 
     def validate(self):
         """Validate object and fill in missing values."""
-        if not self.InternalMassConstruction:
+        if self.InternalMassConstruction is None:
             internal_mass = InternalMass.generic_internalmass_from_zone(self)
             self.InternalMassConstruction = internal_mass.construction
             self.InternalMassExposedPerFloorArea = (

--- a/archetypal/template/zonedefinition.py
+++ b/archetypal/template/zonedefinition.py
@@ -693,7 +693,7 @@ class ZoneDefinition(UmiBase):
 
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/zonedefinition.py
+++ b/archetypal/template/zonedefinition.py
@@ -25,6 +25,7 @@ class ZoneDefinition(UmiBase):
 
     .. image:: ../images/template/zoneinfo-zone.png
     """
+    _CREATED_OBJECTS = []
 
     __slots__ = (
         "_internal_mass_exposed_per_floor_area",
@@ -120,8 +121,8 @@ class ZoneDefinition(UmiBase):
         self.multiplier = multiplier
         self.is_core = is_core
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def Constructions(self):

--- a/archetypal/umi_template.py
+++ b/archetypal/umi_template.py
@@ -273,8 +273,7 @@ class UmiTemplateLibrary:
         if keep_all_zones:
             _zones = set(
                 obj.get_unique()
-                for obj in UmiBase.CREATED_OBJECTS
-                if isinstance(obj, ZoneDefinition)
+                for obj in ZoneDefinition._CREATED_OBJECTS
             )
             for zone in _zones:
                 umi_template.ZoneDefinitions.append(zone)

--- a/archetypal/umi_template.py
+++ b/archetypal/umi_template.py
@@ -271,10 +271,7 @@ class UmiTemplateLibrary:
         ]
 
         if keep_all_zones:
-            _zones = set(
-                obj.get_unique()
-                for obj in ZoneDefinition._CREATED_OBJECTS
-            )
+            _zones = set(obj.get_unique() for obj in ZoneDefinition._CREATED_OBJECTS)
             for zone in _zones:
                 umi_template.ZoneDefinitions.append(zone)
             exceptions = [ZoneDefinition.__name__]
@@ -340,17 +337,15 @@ class UmiTemplateLibrary:
         # with datastore, create each objects
         t = cls(name)
         t.GasMaterials = [
-            GasMaterial.from_dict(store, allow_duplicates=True)
+            GasMaterial.from_dict(store, allow_duplicates=False)
             for store in datastore["GasMaterials"]
         ]
         t.GlazingMaterials = [
-            GlazingMaterial.from_dict(
-                store,
-            )
+            GlazingMaterial.from_dict(store, allow_duplicates=False)
             for store in datastore["GlazingMaterials"]
         ]
         t.OpaqueMaterials = [
-            OpaqueMaterial.from_dict(store, allow_duplicates=True)
+            OpaqueMaterial.from_dict(store, allow_duplicates=False)
             for store in datastore["OpaqueMaterials"]
         ]
         t.OpaqueConstructions = [

--- a/archetypal/umi_template.py
+++ b/archetypal/umi_template.py
@@ -610,7 +610,10 @@ class UmiTemplateLibrary:
             UniqueName.existing = set()
             obj: UmiBase
             for obj in group:
-                data = obj.to_dict()
+                try:
+                    data = obj.to_dict()
+                except AttributeError as e:
+                    raise AttributeError(f"{e} for {obj}")
                 data.update({"Name": UniqueName(data.get("Name"))})
                 data_dict.setdefault(group_name, []).append(data)
 

--- a/archetypal/utils.py
+++ b/archetypal/utils.py
@@ -10,6 +10,7 @@ import datetime as dt
 import json
 import logging
 import logging as lg
+import math
 import multiprocessing
 import os
 import sys
@@ -766,3 +767,11 @@ class CustomJSONEncoder(json.JSONEncoder):
             return bool(obj)
 
         return obj
+
+
+def signif(x, digits=4):
+    """Return number rounded to significant digits."""
+    if x == 0 or not math.isfinite(x):
+        return x
+    digits -= math.ceil(math.log10(abs(x)))
+    return round(x, digits)

--- a/tests/test_umi.py
+++ b/tests/test_umi.py
@@ -108,11 +108,10 @@ class TestUmiTemplate:
         ]
         wf = "tests/input_data/CAN_PQ_Montreal.Intl.AP.716270_CWEC.epw"
         a = UmiTemplateLibrary.from_idf_files(
-            idf_source, wf, name="Mixed_Files", processors=-1
+            idf_source, wf, name="Mixed_Files", processors=-1, debug=True
         )
 
         data_dict = a.to_dict()
-        a.to_dict()
         assert no_duplicates(data_dict)
 
     @pytest.mark.skipif(


### PR DESCRIPTION
This proposes a few changes to achieve approximately a one order of magnitude speed improvement for `UmiTemplateLibrary.unique_components()`. The yappi profiler was used to identify methods that increased significantly the runtime:

1. CREATED_OBJECTS has been moved to each subclass of the UmiBase class, making finding unique_components much faster
2. When evaluating the `validate` method of UmiBase components, checking each attributes for their "nullity" instead of their boolean existance (eg. `if attr` vs `if attr is None`), further speeds up performance.
3. Validation is now not performed by default. Only when saving (UmiTemplateLibrary.save()) is validation performed.

This PR also introduces a simple change to GasMaterial, GlazingMaterial and OpaqueMaterial that renders them "non-duplicatable". Unique objects will choose an equivalent object regardless of the name based on it's properties.