### PR TITLE
Feature/parents lookup

### DIFF
--- a/archetypal/template/building_template.py
+++ b/archetypal/template/building_template.py
@@ -583,7 +583,7 @@ class BuildingTemplate(UmiBase):
         recursive_replace(self)
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/building_template.py
+++ b/archetypal/template/building_template.py
@@ -31,6 +31,7 @@ class BuildingTemplate(UmiBase):
 
     .. image:: ../images/template/buildingtemplate.png
     """
+
     _CREATED_OBJECTS = []
 
     __slots__ = (
@@ -657,6 +658,13 @@ class BuildingTemplate(UmiBase):
                     self.Version == other.Version,
                 ]
             )
+
+    @property
+    def ParentTemplates(self):
+        """Bails out of Parent Templates recursive call from UmiBase
+        And returns array of self for concatenation
+        """
+        return {self}
 
     @property
     def children(self):

--- a/archetypal/template/building_template.py
+++ b/archetypal/template/building_template.py
@@ -565,7 +565,7 @@ class BuildingTemplate(UmiBase):
         """Replace recursively every objects with the first equivalent object."""
 
         def recursive_replace(umibase):
-            for key, obj in umibase.mapping().items():
+            for key, obj in umibase.mapping(validate=False).items():
                 if isinstance(
                     obj, (UmiBase, MaterialLayer, YearSchedulePart, MassRatio)
                 ):

--- a/archetypal/template/building_template.py
+++ b/archetypal/template/building_template.py
@@ -31,6 +31,7 @@ class BuildingTemplate(UmiBase):
 
     .. image:: ../images/template/buildingtemplate.png
     """
+    _CREATED_OBJECTS = []
 
     __slots__ = (
         "_partition_ratio",
@@ -114,8 +115,8 @@ class BuildingTemplate(UmiBase):
         self.AuthorEmails = AuthorEmails if AuthorEmails else []
         self.Version = Version
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def Perimeter(self):

--- a/archetypal/template/conditioning.py
+++ b/archetypal/template/conditioning.py
@@ -1495,7 +1495,7 @@ class ZoneConditioning(UmiBase):
         if self.MinFreshAirPerArea is None:
             self.MinFreshAirPerArea = 0
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/conditioning.py
+++ b/archetypal/template/conditioning.py
@@ -88,6 +88,7 @@ class ZoneConditioning(UmiBase):
 
     .. image:: ../images/template/zoninfo-conditioning.png
     """
+    _CREATED_OBJECTS = []
 
     __slots__ = (
         "_cooling_setpoint",
@@ -285,8 +286,8 @@ class ZoneConditioning(UmiBase):
 
         self.area = area
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def area(self):

--- a/archetypal/template/conditioning.py
+++ b/archetypal/template/conditioning.py
@@ -1488,11 +1488,11 @@ class ZoneConditioning(UmiBase):
             self.CoolingSchedule = UmiSchedule.constant_schedule()
         if self.MechVentSchedule is None:
             self.MechVentSchedule = UmiSchedule.constant_schedule()
-        if not self.IsMechVentOn:
+        if self.IsMechVentOn is None:
             self.IsMechVentOn = False
-        if not self.MinFreshAirPerPerson:
+        if self.MinFreshAirPerPerson is None:
             self.MinFreshAirPerPerson = 0
-        if not self.MinFreshAirPerArea:
+        if self.MinFreshAirPerArea is None:
             self.MinFreshAirPerArea = 0
 
     def mapping(self, validate=True):

--- a/archetypal/template/constructions/internal_mass.py
+++ b/archetypal/template/constructions/internal_mass.py
@@ -3,7 +3,7 @@ from operator import add
 
 from validator_collection import validators
 
-from archetypal.template.constructions.opaque_construction import OpaqueConstruction
+import archetypal.template.constructions.opaque_construction
 
 
 class InternalMass:
@@ -27,15 +27,18 @@ class InternalMass:
         )
 
     @property
-    def construction(self) -> OpaqueConstruction:
+    def construction(self):
         """Get or set the construction."""
         return self._construction
 
     @construction.setter
     def construction(self, value):
-        assert isinstance(value, OpaqueConstruction), (
+        assert isinstance(
+            value,
+            archetypal.template.constructions.opaque_construction.OpaqueConstruction,
+        ), (
             f"Input value error for {value}. construction must be of type "
-            f"{OpaqueConstruction}, not {type(value)}."
+            f"{archetypal.template.constructions.opaque_construction.OpaqueConstruction}, not {type(value)}."
         )
         self._construction = value
 
@@ -73,7 +76,9 @@ class InternalMass:
         for int_obj in internal_mass_objs:
             if int_obj.key.upper() == "INTERNALMASS":
                 mass_opaque_constructions.append(
-                    OpaqueConstruction.from_epbunch(int_obj, Category="Internal Mass")
+                    archetypal.template.constructions.opaque_construction.OpaqueConstruction.from_epbunch(
+                        int_obj, Category="Internal Mass"
+                    )
                 )
                 area += float(int_obj.Surface_Area)
 
@@ -94,7 +99,9 @@ class InternalMass:
         Args:
             zone_epbunch (EpBunch): A ZoneDefinition object.
         """
-        construction = OpaqueConstruction.generic_internalmass()
+        construction = (
+            archetypal.template.constructions.opaque_construction.OpaqueConstruction.generic_internalmass()
+        )
         return cls(
             surface_name=f"{zone_epbunch.Name} InternalMass",
             total_area_exposed_to_zone=0,

--- a/archetypal/template/constructions/opaque_construction.py
+++ b/archetypal/template/constructions/opaque_construction.py
@@ -465,7 +465,7 @@ class OpaqueConstruction(LayeredConstruction):
             # Iterate over the construction's layers
             material = epbunch.get_referenced_object(layer)
             if material:
-                o = OpaqueMaterial.from_epbunch(material, allow_duplicates=True)
+                o = OpaqueMaterial.from_epbunch(material, allow_duplicates=False)
                 try:
                     thickness = material.Thickness
                 except BadEPFieldError:

--- a/archetypal/template/constructions/opaque_construction.py
+++ b/archetypal/template/constructions/opaque_construction.py
@@ -31,6 +31,8 @@ class OpaqueConstruction(LayeredConstruction):
         * solar_reflectance_index
     """
 
+    _CREATED_OBJECTS = []
+
     __slots__ = ("area",)
 
     def __init__(self, Name, Layers, **kwargs):
@@ -45,8 +47,8 @@ class OpaqueConstruction(LayeredConstruction):
         super(OpaqueConstruction, self).__init__(Name, Layers, **kwargs)
         self.area = 1
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def r_value(self):

--- a/archetypal/template/constructions/opaque_construction.py
+++ b/archetypal/template/constructions/opaque_construction.py
@@ -493,7 +493,7 @@ class OpaqueConstruction(LayeredConstruction):
 
         return data_dict
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/constructions/opaque_construction.py
+++ b/archetypal/template/constructions/opaque_construction.py
@@ -7,6 +7,8 @@ import numpy as np
 from eppy.bunch_subclass import BadEPFieldError
 from validator_collection import validators
 
+import archetypal.template.zone_construction_set
+import archetypal.template.zonedefinition
 from archetypal.template.constructions.base_construction import LayeredConstruction
 from archetypal.template.materials.material_layer import MaterialLayer
 from archetypal.template.materials.opaque_material import OpaqueMaterial
@@ -575,3 +577,30 @@ class OpaqueConstruction(LayeredConstruction):
                 for i, layer in enumerate(self.Layers[1:])
             },
         )
+
+    @property
+    def Parents(self):
+        """ Get the parents of the OpaqueConstruction object"""
+        parents = {}
+        for zd in archetypal.template.zonedefinition.ZoneDefinition._CREATED_OBJECTS:
+            if (
+                zd.InternalMassConstruction == self
+                and zd.InternalMassConstruction.Name == self.Name
+            ):
+                if zd not in parents:
+                    parents[zd] = set()
+                parents[zd].add("InternalMassConstruction")
+        for (
+            zcs
+        ) in (
+            archetypal.template.zone_construction_set.ZoneConstructionSet._CREATED_OBJECTS
+        ):
+            for structure in ["Facade", "Ground", "Slab", "Partition", "Roof"]:
+                if (
+                    getattr(zcs, structure) == self
+                    and getattr(zcs, structure).Name == self.Name
+                ):
+                    if zcs not in parents:
+                        parents[zcs] = set()
+                    parents[zcs].add(structure)
+        return parents

--- a/archetypal/template/constructions/opaque_construction.py
+++ b/archetypal/template/constructions/opaque_construction.py
@@ -408,7 +408,7 @@ class OpaqueConstruction(LayeredConstruction):
         return OpaqueConstruction(
             Name="InternalMass",
             Layers=[MaterialLayer(Material=mat, Thickness=0.15)],
-            Category="InternalMass",
+            Category="Internal Mass",
             **kwargs,
         )
 

--- a/archetypal/template/constructions/window_construction.py
+++ b/archetypal/template/constructions/window_construction.py
@@ -337,7 +337,7 @@ class WindowConstruction(LayeredConstruction):
 
         return idf.newidfobject("CONSTRUCTION", **data)
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/constructions/window_construction.py
+++ b/archetypal/template/constructions/window_construction.py
@@ -12,6 +12,7 @@ from enum import Enum
 
 from validator_collection import validators
 
+import archetypal.template.window_setting
 from archetypal.simple_glazing import calc_simple_glazing
 from archetypal.template.constructions.base_construction import LayeredConstruction
 from archetypal.template.materials.gas_layer import GasLayer
@@ -779,3 +780,14 @@ class WindowConstruction(LayeredConstruction):
             abs(desired - actual) < 1.5 * 10 ** (-3)
             for desired, actual in zip(temperatures_last, temperatures_next)
         )
+
+    @property
+    def Parents(self):
+        """ Get the parents of the window Construction object"""
+        parents = {}
+        for ws in archetypal.template.window_setting.WindowSetting._CREATED_OBJECTS:
+            if ws.Construction == self and ws.Construction.Name == self.Name:
+                if ws not in parents:
+                    parents[ws] = set()
+                parents[ws].add("Construction")
+        return parents

--- a/archetypal/template/constructions/window_construction.py
+++ b/archetypal/template/constructions/window_construction.py
@@ -63,6 +63,8 @@ class WindowConstruction(LayeredConstruction):
     .. image:: ../images/template/constructions-window.png
     """
 
+    _CREATED_OBJECTS = []
+
     _CATEGORIES = ("single", "double", "triple", "quadruple")
 
     __slots__ = ("_category",)
@@ -85,8 +87,8 @@ class WindowConstruction(LayeredConstruction):
         )
         self.Category = Category  # set here for validators
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def Category(self):

--- a/archetypal/template/dhw.py
+++ b/archetypal/template/dhw.py
@@ -19,6 +19,7 @@ class DomesticHotWaterSetting(UmiBase):
 
     .. image:: ../images/template/zoneinfo-dhw.png
     """
+    _CREATED_OBJECTS = []
 
     __slots__ = (
         "_flow_rate_per_floor_area",
@@ -61,8 +62,8 @@ class DomesticHotWaterSetting(UmiBase):
         self.WaterSchedule = WaterSchedule
         self.area = area
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def FlowRatePerFloorArea(self):

--- a/archetypal/template/dhw.py
+++ b/archetypal/template/dhw.py
@@ -470,7 +470,7 @@ class DomesticHotWaterSetting(UmiBase):
 
         return reduce(DomesticHotWaterSetting.combine, z_dhw_list)
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/load.py
+++ b/archetypal/template/load.py
@@ -623,7 +623,7 @@ class ZoneLoad(UmiBase):
             self.PeopleDensity = 0
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/load.py
+++ b/archetypal/template/load.py
@@ -42,6 +42,7 @@ class ZoneLoad(UmiBase):
 
     .. image:: ../images/template/zoneinfo-loads.png
     """
+    _CREATED_OBJECTS = []
 
     __slots__ = (
         "_dimming_type",
@@ -131,8 +132,8 @@ class ZoneLoad(UmiBase):
         self.area = area
         self.volume = volume
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def DimmingType(self):

--- a/archetypal/template/load.py
+++ b/archetypal/template/load.py
@@ -599,27 +599,27 @@ class ZoneLoad(UmiBase):
 
     def validate(self):
         """Validate object and fill in missing values."""
-        if not self.DimmingType:
+        if self.DimmingType is None:
             self.DimmingType = DimmingTypes.Continuous
-        if not self.EquipmentAvailabilitySchedule:
+        if self.EquipmentAvailabilitySchedule is None:
             self.EquipmentAvailabilitySchedule = UmiSchedule.constant_schedule()
-        if not self.EquipmentPowerDensity:
+        if self.EquipmentPowerDensity is None:
             self.EquipmentPowerDensity = 0
-        if not self.IlluminanceTarget:
+        if self.IlluminanceTarget is None:
             self.IlluminanceTarget = 500
-        if not self.LightingPowerDensity:
+        if self.LightingPowerDensity is None:
             self.LightingPowerDensity = 0
-        if not self.LightsAvailabilitySchedule:
+        if self.LightsAvailabilitySchedule is None:
             self.LightsAvailabilitySchedule = UmiSchedule.constant_schedule()
-        if not self.OccupancySchedule:
+        if self.OccupancySchedule is None:
             self.OccupancySchedule = UmiSchedule.constant_schedule()
-        if not self.IsEquipmentOn:
+        if self.IsEquipmentOn is None:
             self.IsEquipmentOn = False
-        if not self.IsLightingOn:
+        if self.IsLightingOn is None:
             self.IsLightingOn = False
-        if not self.IsPeopleOn:
+        if self.IsPeopleOn is None:
             self.IsPeopleOn = False
-        if not self.PeopleDensity:
+        if self.PeopleDensity is None:
             self.PeopleDensity = 0
         return self
 

--- a/archetypal/template/materials/gas_material.py
+++ b/archetypal/template/materials/gas_material.py
@@ -14,6 +14,7 @@ class GasMaterial(MaterialBase):
 
     .. image:: ../images/template/materials-gas.png
     """
+    _CREATED_OBJECTS = []
 
     __slots__ = ("_type", "_conductivity", "_density")
 
@@ -39,8 +40,8 @@ class GasMaterial(MaterialBase):
         self.Conductivity = Conductivity
         self.Density = Density
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def Name(self):

--- a/archetypal/template/materials/gas_material.py
+++ b/archetypal/template/materials/gas_material.py
@@ -178,7 +178,7 @@ class GasMaterial(MaterialBase):
             Thickness=thickness,
         )
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/materials/gas_material.py
+++ b/archetypal/template/materials/gas_material.py
@@ -14,6 +14,7 @@ class GasMaterial(MaterialBase):
 
     .. image:: ../images/template/materials-gas.png
     """
+
     _CREATED_OBJECTS = []
 
     __slots__ = ("_type", "_conductivity", "_density")

--- a/archetypal/template/materials/glazing_material.py
+++ b/archetypal/template/materials/glazing_material.py
@@ -17,6 +17,7 @@ class GlazingMaterial(MaterialBase):
     .. image:: ../images/template/materials-glazing.png
 
     """
+
     _CREATED_OBJECTS = []
 
     __slots__ = (

--- a/archetypal/template/materials/glazing_material.py
+++ b/archetypal/template/materials/glazing_material.py
@@ -365,7 +365,7 @@ class GlazingMaterial(MaterialBase):
             Dirt_Correction_Factor_for_Solar_and_Visible_Transmittance=self.DirtFactor,
         )
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/materials/glazing_material.py
+++ b/archetypal/template/materials/glazing_material.py
@@ -17,6 +17,7 @@ class GlazingMaterial(MaterialBase):
     .. image:: ../images/template/materials-glazing.png
 
     """
+    _CREATED_OBJECTS = []
 
     __slots__ = (
         "_ir_emissivity_back",
@@ -104,8 +105,8 @@ class GlazingMaterial(MaterialBase):
         self.SolarReflectanceFront = SolarReflectanceFront
         self.SolarTransmittance = SolarTransmittance
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def Conductivity(self):

--- a/archetypal/template/materials/material_base.py
+++ b/archetypal/template/materials/material_base.py
@@ -3,6 +3,7 @@
 import numpy as np
 from validator_collection import validators
 
+import archetypal.template.constructions
 from archetypal.template.umi_base import UmiBase
 
 
@@ -185,3 +186,40 @@ class MaterialBase(UmiBase):
     def validate(self):
         """Validate object and fill in missing values."""
         return self
+
+    @property
+    def Parents(self):
+        """ Get the parents of a Material object"""
+        parents = {}
+        for (
+            wc
+        ) in (
+            archetypal.template.constructions.window_construction.WindowConstruction._CREATED_OBJECTS
+        ):
+            for i, layer in enumerate(wc.Layers):
+                if layer.Material == self and layer.Material.Name == self.Name:
+                    if wc not in parents:
+                        parents[wc] = set()
+                    parents[wc].add(i)
+        for (
+            oc
+        ) in (
+            archetypal.template.constructions.opaque_construction.OpaqueConstruction._CREATED_OBJECTS
+        ):
+            for i, layer in enumerate(oc.Layers):
+                if layer.Material == self and layer.Material.Name == self.Name:
+                    if oc not in parents:
+                        parents[oc] = set()
+                    parents[oc].add(i)
+        for (
+            structure
+        ) in archetypal.template.structure.StructureInformation._CREATED_OBJECTS:
+            for i, mass_ratio in enumerate(structure.MassRatios):
+                if (
+                    mass_ratio.Material == self
+                    and mass_ratio.Material.Name == self.Name
+                ):
+                    if structure not in parents:
+                        parents[structure] = set()
+                    parents[structure].add(i)
+        return parents

--- a/archetypal/template/materials/material_layer.py
+++ b/archetypal/template/materials/material_layer.py
@@ -2,6 +2,7 @@
 
 import collections
 import logging as lg
+import math
 
 from sigfig import round
 from validator_collection import validators
@@ -143,7 +144,10 @@ class MaterialLayer(object):
             return NotImplemented
         else:
             return all(
-                [self.Thickness == other.Thickness, self.Material == other.Material]
+                [
+                    math.isclose(self.Thickness, other.Thickness, abs_tol=0.001),
+                    self.Material == other.Material,
+                ]
             )
 
     def __repr__(self):

--- a/archetypal/template/materials/nomass_material.py
+++ b/archetypal/template/materials/nomass_material.py
@@ -390,7 +390,7 @@ class NoMassMaterial(MaterialBase):
             setattr(self, "VisibleAbsorptance", 0.7)
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/materials/nomass_material.py
+++ b/archetypal/template/materials/nomass_material.py
@@ -14,6 +14,8 @@ from archetypal.utils import log
 class NoMassMaterial(MaterialBase):
     """Use this component to create a custom no mass material."""
 
+    _CREATED_OBJECTS = []
+
     _ROUGHNESS_TYPES = (
         "VeryRough",
         "Rough",
@@ -77,8 +79,8 @@ class NoMassMaterial(MaterialBase):
         self.VisibleAbsorptance = VisibleAbsorptance
         self.MoistureDiffusionResistance = MoistureDiffusionResistance
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def r_value(self):

--- a/archetypal/template/materials/opaque_material.py
+++ b/archetypal/template/materials/opaque_material.py
@@ -7,7 +7,7 @@ from validator_collection import validators
 
 from archetypal.template.materials import GasMaterial
 from archetypal.template.materials.material_base import MaterialBase
-from archetypal.utils import log
+from archetypal.utils import log, signif
 
 
 class OpaqueMaterial(MaterialBase):
@@ -133,7 +133,8 @@ class OpaqueMaterial(MaterialBase):
 
     @Conductivity.setter
     def Conductivity(self, value):
-        self._conductivity = validators.float(value, minimum=0)
+        value = validators.float(value, minimum=0)
+        self._conductivity = signif(value)
 
     @property
     def Density(self):
@@ -142,7 +143,8 @@ class OpaqueMaterial(MaterialBase):
 
     @Density.setter
     def Density(self, value):
-        self._density = validators.float(value, minimum=0)
+        value = validators.float(value, minimum=0)
+        self._density = signif(value)
 
     @property
     def Roughness(self):
@@ -182,7 +184,8 @@ class OpaqueMaterial(MaterialBase):
 
     @SpecificHeat.setter
     def SpecificHeat(self, value):
-        self._specific_heat = validators.float(value, minimum=100)
+        value = validators.float(value, minimum=100)
+        self._specific_heat = signif(value)
 
     @property
     def ThermalEmittance(self):

--- a/archetypal/template/materials/opaque_material.py
+++ b/archetypal/template/materials/opaque_material.py
@@ -16,6 +16,8 @@ class OpaqueMaterial(MaterialBase):
     .. image:: ../images/template/materials-opaque.png
     """
 
+    _CREATED_OBJECTS = []
+
     _ROUGHNESS_TYPES = (
         "VeryRough",
         "Rough",
@@ -121,8 +123,8 @@ class OpaqueMaterial(MaterialBase):
         self._key: str = kwargs.get("_key", "")
         # TODO: replace when NoMass and AirGap when properly is supported
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def Conductivity(self):

--- a/archetypal/template/materials/opaque_material.py
+++ b/archetypal/template/materials/opaque_material.py
@@ -531,7 +531,7 @@ class OpaqueMaterial(MaterialBase):
             setattr(self, "VisibleAbsorptance", 0.7)
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/schedule.py
+++ b/archetypal/template/schedule.py
@@ -247,7 +247,7 @@ class UmiSchedule(Schedule, UmiBase):
         """Validate object and fill in missing values."""
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:
@@ -620,7 +620,7 @@ class DaySchedule(UmiSchedule):
 
         return data_dict
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:
@@ -799,7 +799,7 @@ class WeekSchedule(UmiSchedule):
 
         return data_dict
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:
@@ -1031,7 +1031,7 @@ class YearSchedule(UmiSchedule):
 
         return idf.newidfobject(key="Schedule:Year".upper(), **new_dict)
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/schedule.py
+++ b/archetypal/template/schedule.py
@@ -17,6 +17,7 @@ from archetypal.utils import log
 
 class UmiSchedule(Schedule, UmiBase):
     """Class that handles Schedules."""
+    _CREATED_OBJECTS = []
 
     __slots__ = ("_quantity",)
 
@@ -31,8 +32,8 @@ class UmiSchedule(Schedule, UmiBase):
         super(UmiSchedule, self).__init__(Name, **kwargs)
         self.quantity = quantity
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def quantity(self):
@@ -1067,7 +1068,7 @@ class YearSchedule(UmiSchedule):
                     next(
                         (
                             x
-                            for x in self.CREATED_OBJECTS
+                            for x in self._CREATED_OBJECTS
                             if x.Name == week_day_schedule_name
                             and type(x).__name__ == "WeekSchedule"
                         )

--- a/archetypal/template/structure.py
+++ b/archetypal/template/structure.py
@@ -212,7 +212,7 @@ class StructureInformation(ConstructionBase):
         """Validate object and fill in missing values."""
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/structure.py
+++ b/archetypal/template/structure.py
@@ -4,6 +4,7 @@ import collections
 
 from validator_collection import validators
 
+import archetypal.template.building_template
 from archetypal.template.constructions.base_construction import ConstructionBase
 from archetypal.template.materials.opaque_material import OpaqueMaterial
 
@@ -262,6 +263,19 @@ class StructureInformation(ConstructionBase):
     def __copy__(self):
         """Create a copy of self."""
         return self.__class__(**self.mapping(validate=False))
+
+    @property
+    def Parents(self):
+        """ Get the parents of the Structure object"""
+        parents = {}
+        for (
+            bt
+        ) in archetypal.template.building_template.BuildingTemplate._CREATED_OBJECTS:
+            if bt.Structure == self and bt.Structure.Name == self.Name:
+                if bt not in parents:
+                    parents[bt] = set()
+                parents[bt].add("Structure")
+        return parents
 
     @property
     def children(self):

--- a/archetypal/template/structure.py
+++ b/archetypal/template/structure.py
@@ -139,6 +139,8 @@ class StructureInformation(ConstructionBase):
     .. image:: ../images/template/constructions-structure.png
     """
 
+    _CREATED_OBJECTS = []
+
     __slots__ = ("_mass_ratios",)
 
     def __init__(self, Name, MassRatios, **kwargs):
@@ -151,8 +153,8 @@ class StructureInformation(ConstructionBase):
         super(StructureInformation, self).__init__(Name, **kwargs)
         self.MassRatios = MassRatios
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def MassRatios(self):

--- a/archetypal/template/umi_base.py
+++ b/archetypal/template/umi_base.py
@@ -410,8 +410,7 @@ class UmiBase(object):
                         (
                             x
                             for x in self._CREATED_OBJECTS
-                            if x == self
-                            and x.Name == self.Name
+                            if x == self and x.Name == self.Name
                         ),
                         key=lambda x: x.unit_number,
                     )
@@ -424,10 +423,7 @@ class UmiBase(object):
             obj = next(
                 iter(
                     sorted(
-                        (
-                            x
-                            for x in self._CREATED_OBJECTS
-                        ),
+                        (x for x in self._CREATED_OBJECTS),
                         key=lambda x: x.unit_number,
                     )
                 ),
@@ -435,6 +431,15 @@ class UmiBase(object):
             )
 
         return obj
+
+    @property
+    def ParentTemplates(self):
+        """ Get the parent templates of an UmiBase object"""
+        templates = set()
+        for parent in self.Parents.keys():
+            # Recursive call terminates at Parent Template level, or if self.Parents is empty
+            templates = templates.union(parent.ParentTemplates)
+        return templates
 
 
 class UserSet(Hashable, MutableSet):

--- a/archetypal/template/umi_base.py
+++ b/archetypal/template/umi_base.py
@@ -55,7 +55,6 @@ class UmiBase(object):
         "_allow_duplicates",
         "_unit_number",
     )
-    CREATED_OBJECTS = []
     _ids = itertools.count(0)  # unique id for each class instance
 
     def __init__(
@@ -239,15 +238,6 @@ class UmiBase(object):
         """Return UmiBase dictionary representation."""
         return {"$id": "{}".format(self.id), "Name": "{}".format(self.Name)}
 
-    @classmethod
-    def get_classref(cls, ref):
-        return next(
-            iter(
-                [value for value in UmiBase.CREATED_OBJECTS if value.id == ref["$ref"]]
-            ),
-            None,
-        )
-
     def get_ref(self, ref):
         pass
 
@@ -380,7 +370,7 @@ class UmiBase(object):
             return other
         if other is None:
             return self
-        self.CREATED_OBJECTS.remove(self)
+        self._CREATED_OBJECTS.remove(self)
         id = self.id
         new_obj = self.combine(other, allow_duplicates=allow_duplicates)
         new_obj.id = id
@@ -419,10 +409,9 @@ class UmiBase(object):
                     sorted(
                         (
                             x
-                            for x in UmiBase.CREATED_OBJECTS
+                            for x in self._CREATED_OBJECTS
                             if x == self
                             and x.Name == self.Name
-                            and type(x) == type(self)
                         ),
                         key=lambda x: x.unit_number,
                     )
@@ -437,8 +426,7 @@ class UmiBase(object):
                     sorted(
                         (
                             x
-                            for x in UmiBase.CREATED_OBJECTS
-                            if x == self and type(x) == type(self)
+                            for x in self._CREATED_OBJECTS
                         ),
                         key=lambda x: x.unit_number,
                     )

--- a/archetypal/template/umi_base.py
+++ b/archetypal/template/umi_base.py
@@ -382,7 +382,7 @@ class UmiBase(object):
         """Validate UmiObjects and fills in missing values."""
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/ventilation.py
+++ b/archetypal/template/ventilation.py
@@ -682,11 +682,11 @@ class VentilationSetting(UmiBase):
 
     def validate(self):
         """Validate object and fill in missing values."""
-        if not self.NatVentSchedule:
+        if self.NatVentSchedule is None:
             self.NatVentSchedule = UmiSchedule.constant_schedule(
                 value=0, Name="AlwaysOff", allow_duplicates=True
             )
-        if not self.ScheduledVentilationSchedule:
+        if self.ScheduledVentilationSchedule is None:
             self.ScheduledVentilationSchedule = UmiSchedule.constant_schedule(
                 value=0, Name="AlwaysOff", allow_duplicates=True
             )
@@ -699,7 +699,8 @@ class VentilationSetting(UmiBase):
         Args:
             validate:
         """
-        self.validate()
+        if validate:
+            self.validate()
 
         return dict(
             Afn=self.Afn,

--- a/archetypal/template/ventilation.py
+++ b/archetypal/template/ventilation.py
@@ -62,6 +62,7 @@ class VentilationSetting(UmiBase):
 
     .. image:: ../images/template/zoneinfo-ventilation.png
     """
+    _CREATED_OBJECTS = []
 
     __slots__ = (
         "_infiltration",
@@ -198,8 +199,8 @@ class VentilationSetting(UmiBase):
         self.area = area
         self.volume = volume
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def NatVentSchedule(self):

--- a/archetypal/template/ventilation.py
+++ b/archetypal/template/ventilation.py
@@ -693,7 +693,7 @@ class VentilationSetting(UmiBase):
 
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/window_setting.py
+++ b/archetypal/template/window_setting.py
@@ -36,6 +36,7 @@ class WindowSetting(UmiBase):
 
     .. _eppy : https://eppy.readthedocs.io/en/latest/
     """
+    _CREATED_OBJECTS = []
 
     __slots__ = (
         "_operable_area",
@@ -131,8 +132,8 @@ class WindowSetting(UmiBase):
 
         self.area = area
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def area(self):

--- a/archetypal/template/window_setting.py
+++ b/archetypal/template/window_setting.py
@@ -883,7 +883,7 @@ class WindowSetting(UmiBase):
 
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/window_setting.py
+++ b/archetypal/template/window_setting.py
@@ -868,15 +868,15 @@ class WindowSetting(UmiBase):
 
     def validate(self):
         """Validate object and fill in missing values."""
-        if not self.AfnWindowAvailability:
+        if self.AfnWindowAvailability is None:
             self.AfnWindowAvailability = UmiSchedule.constant_schedule(
                 value=0, Name="AlwaysOff"
             )
-        if not self.ShadingSystemAvailabilitySchedule:
+        if self.ShadingSystemAvailabilitySchedule is None:
             self.ShadingSystemAvailabilitySchedule = UmiSchedule.constant_schedule(
                 value=0, Name="AlwaysOff"
             )
-        if not self.ZoneMixingAvailabilitySchedule:
+        if self.ZoneMixingAvailabilitySchedule is None:
             self.ZoneMixingAvailabilitySchedule = UmiSchedule.constant_schedule(
                 value=0, Name="AlwaysOff"
             )

--- a/archetypal/template/zone_construction_set.py
+++ b/archetypal/template/zone_construction_set.py
@@ -482,7 +482,7 @@ class ZoneConstructionSet(UmiBase):
                 )
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/zone_construction_set.py
+++ b/archetypal/template/zone_construction_set.py
@@ -12,6 +12,7 @@ from archetypal.utils import log, reduce, timeit
 
 class ZoneConstructionSet(UmiBase):
     """ZoneConstructionSet class."""
+    _CREATED_OBJECTS = []
 
     __slots__ = (
         "_facade",
@@ -80,8 +81,8 @@ class ZoneConstructionSet(UmiBase):
         self.area = area
         self.volume = volume
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def Facade(self):
@@ -463,7 +464,7 @@ class ZoneConstructionSet(UmiBase):
                     iter(
                         filter(
                             lambda x: getattr(x, attr, None) is not None,
-                            UmiBase.CREATED_OBJECTS,
+                            ZoneConstructionSet._CREATED_OBJECTS,
                         )
                     ),
                     None,

--- a/archetypal/template/zonedefinition.py
+++ b/archetypal/template/zonedefinition.py
@@ -693,7 +693,7 @@ class ZoneDefinition(UmiBase):
 
         return self
 
-    def mapping(self, validate=True):
+    def mapping(self, validate=False):
         """Get a dict based on the object properties, useful for dict repr.
 
         Args:

--- a/archetypal/template/zonedefinition.py
+++ b/archetypal/template/zonedefinition.py
@@ -25,6 +25,7 @@ class ZoneDefinition(UmiBase):
 
     .. image:: ../images/template/zoneinfo-zone.png
     """
+    _CREATED_OBJECTS = []
 
     __slots__ = (
         "_internal_mass_exposed_per_floor_area",
@@ -120,8 +121,8 @@ class ZoneDefinition(UmiBase):
         self.multiplier = multiplier
         self.is_core = is_core
 
-        # Only at the end append self to CREATED_OBJECTS
-        self.CREATED_OBJECTS.append(self)
+        # Only at the end append self to _CREATED_OBJECTS
+        self._CREATED_OBJECTS.append(self)
 
     @property
     def Constructions(self):

--- a/archetypal/template/zonedefinition.py
+++ b/archetypal/template/zonedefinition.py
@@ -8,15 +8,16 @@ from eppy.bunch_subclass import BadEPFieldError
 from sigfig import round
 from validator_collection import validators
 
-from archetypal.template.conditioning import ZoneConditioning
-from archetypal.template.constructions.internal_mass import InternalMass
-from archetypal.template.constructions.opaque_construction import OpaqueConstruction
-from archetypal.template.dhw import DomesticHotWaterSetting
-from archetypal.template.load import ZoneLoad
+import archetypal.template.building_template
+import archetypal.template.conditioning as arch_cond
+import archetypal.template.constructions.internal_mass as arch_im  
+import archetypal.template.constructions.opaque_construction as arch_oc
+import archetypal.template.dhw as arch_dhw  
+import archetypal.template.load as arch_zl
+import archetypal.template.ventilation as arch_vent
+import archetypal.template.window_setting as arch_ws
+import archetypal.template.zone_construction_set as arch_zcs
 from archetypal.template.umi_base import UmiBase
-from archetypal.template.ventilation import VentilationSetting
-from archetypal.template.window_setting import WindowSetting
-from archetypal.template.zone_construction_set import ZoneConstructionSet
 from archetypal.utils import log, settings
 
 
@@ -25,6 +26,7 @@ class ZoneDefinition(UmiBase):
 
     .. image:: ../images/template/zoneinfo-zone.png
     """
+
     _CREATED_OBJECTS = []
 
     __slots__ = (
@@ -132,9 +134,9 @@ class ZoneDefinition(UmiBase):
     @Constructions.setter
     def Constructions(self, value):
         if value is not None:
-            assert isinstance(value, ZoneConstructionSet), (
+            assert isinstance(value, arch_zcs.ZoneConstructionSet), (
                 f"Input value error. Constructions must be of "
-                f"type {ZoneConstructionSet}, not {type(value)}."
+                f"type {arch_zcs.ZoneConstructionSet}, not {type(value)}."
             )
         self._constructions = value
 
@@ -146,9 +148,9 @@ class ZoneDefinition(UmiBase):
     @Loads.setter
     def Loads(self, value):
         if value is not None:
-            assert isinstance(value, ZoneLoad), (
+            assert isinstance(value, arch_zl.ZoneLoad), (
                 f"Input value error. Loads must be of "
-                f"type {ZoneLoad}, not {type(value)}."
+                f"type {arch_zl.ZoneLoad}, not {type(value)}."
             )
         self._loads = value
 
@@ -160,9 +162,9 @@ class ZoneDefinition(UmiBase):
     @Conditioning.setter
     def Conditioning(self, value):
         if value is not None:
-            assert isinstance(value, ZoneConditioning), (
+            assert isinstance(value, arch_cond.ZoneConditioning), (
                 f"Input value error. Conditioning must be of "
-                f"type {ZoneConditioning}, not {type(value)}."
+                f"type {arch_cond.ZoneConditioning}, not {type(value)}."
             )
         self._conditioning = value
 
@@ -174,9 +176,9 @@ class ZoneDefinition(UmiBase):
     @Ventilation.setter
     def Ventilation(self, value):
         if value is not None:
-            assert isinstance(value, VentilationSetting), (
+            assert isinstance(value, arch_vent.VentilationSetting), (
                 f"Input value error. Ventilation must be of "
-                f"type {VentilationSetting}, not {type(value)}."
+                f"type {arch_vent.VentilationSetting}, not {type(value)}."
             )
         self._ventilation = value
 
@@ -188,9 +190,9 @@ class ZoneDefinition(UmiBase):
     @DomesticHotWater.setter
     def DomesticHotWater(self, value):
         if value is not None:
-            assert isinstance(value, DomesticHotWaterSetting), (
+            assert isinstance(value, arch_dhw.DomesticHotWaterSetting), (
                 f"Input value error. DomesticHotWater must be of "
-                f"type {DomesticHotWaterSetting}, not {type(value)}."
+                f"type {arch_dhw.DomesticHotWaterSetting}, not {type(value)}."
             )
         self._domestic_hot_water = value
 
@@ -220,9 +222,9 @@ class ZoneDefinition(UmiBase):
     @InternalMassConstruction.setter
     def InternalMassConstruction(self, value):
         if value is not None:
-            assert isinstance(value, OpaqueConstruction), (
+            assert isinstance(value, arch_oc.OpaqueConstruction), (
                 f"Input value error. InternalMassConstruction must be of "
-                f"type {OpaqueConstruction}, not {type(value)}."
+                f"type {arch_oc.OpaqueConstruction}, not {type(value)}."
             )
         self._internal_mass_construction = value
 
@@ -243,9 +245,9 @@ class ZoneDefinition(UmiBase):
     @Windows.setter
     def Windows(self, value):
         if value is not None:
-            assert isinstance(value, WindowSetting), (
+            assert isinstance(value, arch_ws.WindowSetting), (
                 f"Input value error. Windows must be of "
-                f"type {WindowSetting}, not {type(value)}."
+                f"type {arch_ws.WindowSetting}, not {type(value)}."
             )
         self._windows = value
 
@@ -555,19 +557,23 @@ class ZoneDefinition(UmiBase):
         )
 
         if construct_parents:
-            zone.Constructions = ZoneConstructionSet.from_zone(zone, **kwargs)
-            zone.Conditioning = ZoneConditioning.from_zone(zone, ep_bunch, **kwargs)
-            zone.Ventilation = VentilationSetting.from_zone(zone, ep_bunch, **kwargs)
-            zone.DomesticHotWater = DomesticHotWaterSetting.from_zone(
+            zone.Constructions = arch_zcs.ZoneConstructionSet.from_zone(zone, **kwargs)
+            zone.Conditioning = arch_cond.ZoneConditioning.from_zone(
+                zone, ep_bunch, **kwargs
+            )
+            zone.Ventilation = arch_vent.VentilationSetting.from_zone(
+                zone, ep_bunch, **kwargs
+            )
+            zone.DomesticHotWater = arch_dhw.DomesticHotWaterSetting.from_zone(
                 ep_bunch, **kwargs
             )
-            zone.Loads = ZoneLoad.from_zone(zone, ep_bunch, **kwargs)
-            internal_mass_from_zone = InternalMass.from_zone(ep_bunch)
+            zone.Loads = arch_zl.ZoneLoad.from_zone(zone, ep_bunch, **kwargs)
+            internal_mass_from_zone = arch_im.InternalMass.from_zone(ep_bunch)
             zone.InternalMassConstruction = internal_mass_from_zone.construction
             zone.InternalMassExposedPerFloorArea = (
                 internal_mass_from_zone.total_area_exposed_to_zone
             )
-            zone.Windows = WindowSetting.from_zone(zone, **kwargs)
+            zone.Windows = arch_ws.WindowSetting.from_zone(zone, **kwargs)
 
         log(
             'completed Zone "{}" constructor in {:,.2f} seconds'.format(
@@ -634,30 +640,32 @@ class ZoneDefinition(UmiBase):
             )
 
         new_attr = dict(
-            Conditioning=ZoneConditioning.combine(
+            Conditioning=arch_cond.ZoneConditioning.combine(
                 self.Conditioning, other.Conditioning, weights
             ),
-            Constructions=ZoneConstructionSet.combine(
+            Constructions=arch_zcs.ZoneConstructionSet.combine(
                 self.Constructions, other.Constructions, weights
             ),
-            Ventilation=VentilationSetting.combine(self.Ventilation, other.Ventilation),
-            Windows=WindowSetting.combine(self.Windows, other.Windows, weights),
+            Ventilation=arch_vent.VentilationSetting.combine(
+                self.Ventilation, other.Ventilation
+            ),
+            Windows=arch_ws.WindowSetting.combine(self.Windows, other.Windows, weights),
             DaylightMeshResolution=self.float_mean(
                 other, "DaylightMeshResolution", weights=weights
             ),
             DaylightWorkplaneHeight=self.float_mean(
                 other, "DaylightWorkplaneHeight", weights
             ),
-            DomesticHotWater=DomesticHotWaterSetting.combine(
+            DomesticHotWater=arch_dhw.DomesticHotWaterSetting.combine(
                 self.DomesticHotWater, other.DomesticHotWater
             ),
-            InternalMassConstruction=OpaqueConstruction.combine(
+            InternalMassConstruction=arch_oc.OpaqueConstruction.combine(
                 self.InternalMassConstruction, other.InternalMassConstruction
             ),
             InternalMassExposedPerFloorArea=self.float_mean(
                 other, "InternalMassExposedPerFloorArea", weights
             ),
-            Loads=ZoneLoad.combine(self.Loads, other.Loads, weights),
+            Loads=arch_zl.ZoneLoad.combine(self.Loads, other.Loads, weights),
         )
         new_obj = ZoneDefinition(**meta, **new_attr)
 
@@ -675,7 +683,7 @@ class ZoneDefinition(UmiBase):
     def validate(self):
         """Validate object and fill in missing values."""
         if not self.InternalMassConstruction:
-            internal_mass = InternalMass.generic_internalmass_from_zone(self)
+            internal_mass = arch_im.InternalMass.generic_internalmass_from_zone(self)
             self.InternalMassConstruction = internal_mass.construction
             self.InternalMassExposedPerFloorArea = (
                 internal_mass.total_area_exposed_to_zone
@@ -689,7 +697,7 @@ class ZoneDefinition(UmiBase):
             )
 
         if self.Conditioning is None:
-            self.Conditioning = ZoneConditioning(Name="Unconditioned Zone")
+            self.Conditioning = arch_cond.ZoneConditioning(Name="Unconditioned Zone")
 
         return self
 
@@ -760,6 +768,23 @@ class ZoneDefinition(UmiBase):
     def __copy__(self):
         """Return a copy of self."""
         return self.__class__(**self.mapping(validate=False))
+
+    @property
+    def Parents(self):
+        """ Get the parents of the ZoneDefinition object"""
+        parents = {}
+        for (
+            bt
+        ) in archetypal.template.building_template.BuildingTemplate._CREATED_OBJECTS:
+            if bt.Core == self and bt.Core.Name == self.Name:
+                if bt not in parents:
+                    parents[bt] = set()
+                parents[bt].add("Core")
+            if bt.Perimeter == self and bt.Perimeter.Name == self.Name:
+                if bt not in parents:
+                    parents[bt] = set()
+                parents[bt].add("Perimeter")
+        return parents
 
     @property
     def children(self):

--- a/archetypal/umi_template.py
+++ b/archetypal/umi_template.py
@@ -273,8 +273,7 @@ class UmiTemplateLibrary:
         if keep_all_zones:
             _zones = set(
                 obj.get_unique()
-                for obj in UmiBase.CREATED_OBJECTS
-                if isinstance(obj, ZoneDefinition)
+                for obj in ZoneDefinition._CREATED_OBJECTS
             )
             for zone in _zones:
                 umi_template.ZoneDefinitions.append(zone)

--- a/archetypal/umi_template.py
+++ b/archetypal/umi_template.py
@@ -271,10 +271,7 @@ class UmiTemplateLibrary:
         ]
 
         if keep_all_zones:
-            _zones = set(
-                obj.get_unique()
-                for obj in ZoneDefinition._CREATED_OBJECTS
-            )
+            _zones = set(obj.get_unique() for obj in ZoneDefinition._CREATED_OBJECTS)
             for zone in _zones:
                 umi_template.ZoneDefinitions.append(zone)
             exceptions = [ZoneDefinition.__name__]
@@ -340,17 +337,15 @@ class UmiTemplateLibrary:
         # with datastore, create each objects
         t = cls(name)
         t.GasMaterials = [
-            GasMaterial.from_dict(store, allow_duplicates=True)
+            GasMaterial.from_dict(store, allow_duplicates=False)
             for store in datastore["GasMaterials"]
         ]
         t.GlazingMaterials = [
-            GlazingMaterial.from_dict(
-                store,
-            )
+            GlazingMaterial.from_dict(store, allow_duplicates=False)
             for store in datastore["GlazingMaterials"]
         ]
         t.OpaqueMaterials = [
-            OpaqueMaterial.from_dict(store, allow_duplicates=True)
+            OpaqueMaterial.from_dict(store, allow_duplicates=False)
             for store in datastore["OpaqueMaterials"]
         ]
         t.OpaqueConstructions = [

--- a/archetypal/utils.py
+++ b/archetypal/utils.py
@@ -10,6 +10,7 @@ import datetime as dt
 import json
 import logging
 import logging as lg
+import math
 import multiprocessing
 import os
 import sys
@@ -766,3 +767,11 @@ class CustomJSONEncoder(json.JSONEncoder):
             return bool(obj)
 
         return obj
+
+
+def signif(x, digits=4):
+    """Return number rounded to significant digits."""
+    if x == 0 or not math.isfinite(x):
+        return x
+    digits -= math.ceil(math.log10(abs(x)))
+    return round(x, digits)

--- a/tests/test_umi.py
+++ b/tests/test_umi.py
@@ -84,6 +84,21 @@ class TestUmiTemplate:
         G = a.to_graph(include_orphans=True)
         assert len(G) > n_nodes
 
+    def test_parent_templates(self):
+        """Test realtime graph structure determination of parent templates"""
+        file = "tests/input_data/umi_samples/BostonTemplateLibrary_2.json"
+
+        lib = UmiTemplateLibrary.open(file)
+        for bt in lib.BuildingTemplates:
+            assert bt in bt.Perimeter.ParentTemplates
+            assert bt in bt.Perimeter.Loads.ParentTemplates
+            assert bt in bt.Core.Loads.ParentTemplates
+            assert bt in bt.Core.ParentTemplates
+            bt.Perimeter.Loads = lib.ZoneLoads[0]
+            bt.Core.Loads = lib.ZoneLoads[0]
+        
+        assert {bt for bt in lib.BuildingTemplates} == lib.ZoneLoads[0].ParentTemplates
+
     def test_template_to_template(self):
         """load the json into UmiTemplateLibrary object, then convert back to json and
         compare"""


### PR DESCRIPTION
So this implements the determination of parents at runtime using the new `_CREATED_OBJECTS` functionality.

The only thing that is a little off about it is that the wrapper objects don't have it implemented - e.g. `MassRatios` don't have parents (however the `Material` inside of a `MassRatio` will accurately find the Parents/ParentTemplates, same for a `Material` inside of a `Layer` finding the parent construction or a `WeekSchedule` inside of a `WeekSchedulePart` finding the parent `YearSchedule`).  

Not a big deal IMO, since all UmiBase objects have it at least and it works properly.

There's a little bit of weirdness with the imports - rather than using `from x import y` we use `import x as y` in order to avoid circular imports.  This is because we need to use the parent classes' `_CREATED_OBJECTS` in the children, so the children must import the parents, but... the parents are also already importing the children.  A way to avoid this would be to go back to storing the `_CREATED_OBJECTS` in `UmiBase`, but using a key for each parent class.  That way all the children don't need to import the parent classes...