### PR TITLE
Larger models with more extensible entries that are not defined in the IDD file will raise an error when parsed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 networkx~=2.6.1
-geomeppy @ git+https://github.com/samuelduchesne/geomeppy.git#geomeppy
+geomeppy @ git+https://github.com/samuelduchesne/geomeppy.git@v0.12#geomeppy
 eppy==0.5.56  # for stability
 matplotlib~=3.4  # because of TwoSlopesNorm
 pycountry~=20.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 networkx~=2.6.1
-geomeppy==0.11.8
+geomeppy @ git+https://github.com/samuelduchesne/geomeppy.git#geomeppy
 eppy==0.5.56  # for stability
 matplotlib~=3.4  # because of TwoSlopesNorm
 pycountry~=20.7.3


### PR DESCRIPTION
When parsing large models with `IDF()`, if some components have more extensible entries than is defined in the IDD file, the parsing routine will now raise an error with some guidance as how to fix the IDD.