### PR TITLE
Deprecates StatCan module and skips tests.

### DIFF
--- a/archetypal/dataportal.py
+++ b/archetypal/dataportal.py
@@ -14,6 +14,7 @@ import os
 import re
 import time
 import zipfile
+from warnings import warn
 
 import pandas as pd
 import pycountry as pycountry
@@ -557,6 +558,7 @@ def stat_can_request(response_format, lang="E", dguid="2016A000011124", topic=0,
             footnotes.
         stat (int): 0 or 1. 0 = counts. 1 = rates.
     """
+    warn("The stat can module is deprecated", DeprecationWarning, stacklevel=2)
     prepared_url = (
         "https://www12.statcan.gc.ca/rest/census-recensement"
         f"/CPR2016.{response_format}?lang={lang}&dguid={dguid}&topic="

--- a/tests/test_dataportals.py
+++ b/tests/test_dataportals.py
@@ -219,6 +219,7 @@ def test_download_and_load_bld_window(config):
     assert ws
 
 
+@pytest.mark.skip("APIs seem deprecated.")
 def test_statcan(config):
     data = {"response_format": "json", "lang": "E", "dguid": "2016A000011124", "topic": 5, "notes": 0}
     response = dataportal.stat_can_request(**data)
@@ -228,6 +229,7 @@ def test_statcan(config):
     assert response
 
 
+@pytest.mark.skip("APIs seem deprecated.")
 def test_statcan_error(config):
     # Tests statcan with error in inputs
     data = {"response_format": "json", "lang": "E", "dguid": "wrong_string", "topic": 5, "notes": 0}
@@ -238,6 +240,7 @@ def test_statcan_error(config):
     assert response is None
 
 
+@pytest.mark.skip("APIs seem deprecated.")
 def test_statcan_geo(config):
     data = {"response_format": "json", "lang": "E", "geos": "PR", "cpt": "00"}
     response = dataportal.stat_can_geo_request(**data)
@@ -247,6 +250,7 @@ def test_statcan_geo(config):
     assert response
 
 
+@pytest.mark.skip("APIs seem deprecated.")
 def test_statcan_geo_error(config):
     # Tests statcan_geo with error in inputs
     data = {"response_format": "json", "lang": "E", "geos": "wrong_string", "cpt": "00"}


### PR DESCRIPTION
Adds a deprecation warning to the StatCan module to indicate its obsolescence.

Marks StatCan tests as skipped due to deprecated APIs, preventing failures
during automated testing.