### PR TITLE
Fix Settings type annotation for Python 3.9

### DIFF
--- a/archetypal/__init__.py
+++ b/archetypal/__init__.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging as lg
 from pathlib import Path
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, Optional
 
 from energy_pandas.units import unit_registry
 
@@ -171,7 +171,7 @@ class Settings(BaseSettings, arbitrary_types_allowed=True, validate_assignment=T
         "for ENERGYPLUS_VERSION in os.environ",
     )
 
-    energyplus_location: DirectoryPath | None = Field(
+    energyplus_location: Optional[DirectoryPath] = Field(
         None,
         validation_alias="ENERGYPLUS_LOCATION",
         description="Root directory of the EnergyPlus install.",


### PR DESCRIPTION
## Summary
- use `Optional` for `energyplus_location` to avoid Pydantic type evaluation errors on Python 3.9

## Testing
- `pre-commit run --files archetypal/__init__.py`
- `pytest tests/test_version.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6897bdc426a48333876c3e5a5b40c78f